### PR TITLE
Test deploiement continu

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,30 @@
+name: Deploy to github pages https://betagouv.github.io/mes-aides-analytics/
+
+on:
+  push:
+    branches:
+      - test-deploiement-continu
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v3
+
+    - name: Setup Node.js
+      uses: actions/setup-node@v3
+      with:
+        node-version: 16
+        cache: npm
+
+    - name: Build
+      run: |
+        npm ci
+        npm run build
+        touch out/.nojekyll
+
+    - name: Deploy to github pages
+      uses: JamesIves/github-pages-deploy-action@v4
+      with:
+        folder: out

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -3,7 +3,7 @@ name: Deploy to github pages https://betagouv.github.io/mes-aides-analytics/
 on:
   push:
     branches:
-      - test-deploiement-continu
+      - master
 jobs:
   deploy:
     runs-on: ubuntu-latest


### PR DESCRIPTION
https://trello.com/c/wwzqw8tC/1141-mettre-en-place-du-d%C3%A9ploiement-continu-sur-https-githubcom-betagouv-mes-aides-analytics

Déploie automatiquement le répo sur github-pages à chaque commit sur la branche test-deploiement-continu.

Au merge sur master, il faudra modifier la ligne 6 du script deploy.yml

```yml
- test-deploiement-continu
```

par 

```yml
- master
```