### PR TITLE
Met à jour nivo en version 0.83

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -28,5 +28,9 @@ const configuration = {
     _interetsAidesVeloCsvUrl: `${aidesJeunesUrl}documents/_interetsAidesVelo.csv`,
     commitSHA: process.env.GITHUB_SHA || "local",
   },
+  transpilePackages: ["@nivo"],
+  experimental: {
+    esmExternals: "loose",
+  },
 }
 export default configuration

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
-        "@nivo/bar": "^0.80.0",
+        "@nivo/bar": "^0.83.0",
         "eslint-config-next": "^13.3.4",
         "iframe-resizer": "^4.3.6",
         "next": "^13.3.1",
@@ -286,81 +286,93 @@
       }
     },
     "node_modules/@nivo/annotations": {
-      "version": "0.80.0",
-      "resolved": "https://registry.npmjs.org/@nivo/annotations/-/annotations-0.80.0.tgz",
-      "integrity": "sha512-bC9z0CLjU07LULTMWsqpjovRtHxP7n8oJjqBQBLmHOGB4IfiLbrryBfu9+aEZH3VN2jXHhdpWUz+HxeZzOzsLg==",
+      "version": "0.83.0",
+      "resolved": "https://registry.npmjs.org/@nivo/annotations/-/annotations-0.83.0.tgz",
+      "integrity": "sha512-FkfCprk1a3WCCNcQOfI2+Ww7vqTP/nJjQDVhFYf1YAaEGwXi4+OO4uJAtKtNcGE5cJWdOp+f0Gt4aNPGx7RtEw==",
       "dependencies": {
-        "@nivo/colors": "0.80.0",
-        "@react-spring/web": "9.4.5",
-        "lodash": "^4.17.21"
+        "@nivo/colors": "0.83.0",
+        "@nivo/core": "0.83.0",
+        "@react-spring/web": "9.4.5 || ^9.7.2",
+        "@types/prop-types": "^15.7.2",
+        "lodash": "^4.17.21",
+        "prop-types": "^15.7.2"
       },
       "peerDependencies": {
-        "@nivo/core": "0.80.0",
         "react": ">= 16.14.0 < 19.0.0"
       }
     },
     "node_modules/@nivo/axes": {
-      "version": "0.80.0",
-      "resolved": "https://registry.npmjs.org/@nivo/axes/-/axes-0.80.0.tgz",
-      "integrity": "sha512-AsUyaSHGwQVSEK8QXpsn8X+poZxvakLMYW7crKY1xTGPNw+SU4SSBohPVumm2jMH3fTSLNxLhAjWo71GBJXfdA==",
+      "version": "0.83.0",
+      "resolved": "https://registry.npmjs.org/@nivo/axes/-/axes-0.83.0.tgz",
+      "integrity": "sha512-rHMl+DdXQlY2wl7VCSQNcJi4QNISUWOkcWzJeJeVaYR73Z13SVGgiC7kW0czJuogDTSnDAJ/EcFCGmyGVuznGQ==",
       "dependencies": {
-        "@nivo/scales": "0.80.0",
-        "@react-spring/web": "9.4.5",
+        "@nivo/core": "0.83.0",
+        "@nivo/scales": "0.83.0",
+        "@react-spring/web": "9.4.5 || ^9.7.2",
+        "@types/d3-format": "^1.4.1",
+        "@types/d3-time-format": "^2.3.1",
+        "@types/prop-types": "^15.7.2",
         "d3-format": "^1.4.4",
-        "d3-time-format": "^3.0.0"
+        "d3-time-format": "^3.0.0",
+        "prop-types": "^15.7.2"
       },
       "peerDependencies": {
-        "@nivo/core": "0.80.0",
-        "prop-types": ">= 15.5.10 < 16.0.0",
         "react": ">= 16.14.0 < 19.0.0"
       }
     },
     "node_modules/@nivo/bar": {
-      "version": "0.80.0",
-      "resolved": "https://registry.npmjs.org/@nivo/bar/-/bar-0.80.0.tgz",
-      "integrity": "sha512-woE/S12Sp+RKQeOHtp302WXfy5usj73cV/gjP95PzJxMv+Rn01i1Uwys3BILzc9h4+OxYuWTFqLADAySAmi7qQ==",
+      "version": "0.83.0",
+      "resolved": "https://registry.npmjs.org/@nivo/bar/-/bar-0.83.0.tgz",
+      "integrity": "sha512-QXN6BcT1PiT/YViyoDU4G5mytbOUP1jYbuQmJhDDxKPMLNcZ/pHfThedRGVfDoD1poHBRJtV6mbgeCpAVmlTtw==",
       "dependencies": {
-        "@nivo/annotations": "0.80.0",
-        "@nivo/axes": "0.80.0",
-        "@nivo/colors": "0.80.0",
-        "@nivo/legends": "0.80.0",
-        "@nivo/scales": "0.80.0",
-        "@nivo/tooltip": "0.80.0",
-        "@react-spring/web": "9.4.5",
+        "@nivo/annotations": "0.83.0",
+        "@nivo/axes": "0.83.0",
+        "@nivo/colors": "0.83.0",
+        "@nivo/core": "0.83.0",
+        "@nivo/legends": "0.83.0",
+        "@nivo/scales": "0.83.0",
+        "@nivo/tooltip": "0.83.0",
+        "@react-spring/web": "9.4.5 || ^9.7.2",
+        "@types/d3-scale": "^3.2.3",
+        "@types/d3-shape": "^2.0.0",
         "d3-scale": "^3.2.3",
         "d3-shape": "^1.3.5",
         "lodash": "^4.17.21"
       },
       "peerDependencies": {
-        "@nivo/core": "0.80.0",
         "react": ">= 16.14.0 < 19.0.0"
       }
     },
     "node_modules/@nivo/colors": {
-      "version": "0.80.0",
-      "resolved": "https://registry.npmjs.org/@nivo/colors/-/colors-0.80.0.tgz",
-      "integrity": "sha512-T695Zr411FU4RPo7WDINOAn8f79DPP10SFJmDdEqELE+cbzYVTpXqLGZ7JMv88ko7EOf9qxLQgcBqY69rp9tHQ==",
+      "version": "0.83.0",
+      "resolved": "https://registry.npmjs.org/@nivo/colors/-/colors-0.83.0.tgz",
+      "integrity": "sha512-n34LWYtE2hbd1fdCDP7TCHNZdbiO1PwcvXLo0VsKK5lNPY/FA5SXA7Z9Ubl/ChSwBwbzAsaAhjTy8KzKzSjDcA==",
       "dependencies": {
-        "d3-color": "^2.0.0",
+        "@nivo/core": "0.83.0",
+        "@types/d3-color": "^2.0.0",
+        "@types/d3-scale": "^3.2.3",
+        "@types/d3-scale-chromatic": "^2.0.0",
+        "@types/prop-types": "^15.7.2",
+        "d3-color": "^3.1.0",
         "d3-scale": "^3.2.3",
         "d3-scale-chromatic": "^2.0.0",
-        "lodash": "^4.17.21"
+        "lodash": "^4.17.21",
+        "prop-types": "^15.7.2"
       },
       "peerDependencies": {
-        "@nivo/core": "0.80.0",
-        "prop-types": ">= 15.5.10 < 16.0.0",
         "react": ">= 16.14.0 < 19.0.0"
       }
     },
     "node_modules/@nivo/core": {
-      "version": "0.80.0",
-      "resolved": "https://registry.npmjs.org/@nivo/core/-/core-0.80.0.tgz",
-      "integrity": "sha512-6caih0RavXdWWSfde+rC2pk17WrX9YQlqK26BrxIdXzv3Ydzlh5SkrC7dR2TEvMGBhunzVeLOfiC2DWT1S8CFg==",
-      "peer": true,
+      "version": "0.83.0",
+      "resolved": "https://registry.npmjs.org/@nivo/core/-/core-0.83.0.tgz",
+      "integrity": "sha512-I9fjZAbIPz41JA2WP8Avsud/xk0iiM1nWUzcvZBDebBGFDB5Y1lrldUt9l5kvOeMth3Qj/1lVFTiJxQuojxH4Q==",
       "dependencies": {
-        "@nivo/recompose": "0.80.0",
-        "@react-spring/web": "9.4.5",
-        "d3-color": "^2.0.0",
+        "@nivo/recompose": "0.83.0",
+        "@nivo/tooltip": "0.83.0",
+        "@react-spring/web": "9.4.5 || ^9.7.2",
+        "@types/d3-shape": "^2.0.0",
+        "d3-color": "^3.1.0",
         "d3-format": "^1.4.4",
         "d3-interpolate": "^2.0.1",
         "d3-scale": "^3.2.3",
@@ -369,28 +381,39 @@
         "d3-time-format": "^3.0.0",
         "lodash": "^4.17.21"
       },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/nivo/donate"
+      },
       "peerDependencies": {
-        "@nivo/tooltip": "0.80.0",
         "prop-types": ">= 15.5.10 < 16.0.0",
         "react": ">= 16.14.0 < 19.0.0"
       }
     },
     "node_modules/@nivo/legends": {
-      "version": "0.80.0",
-      "resolved": "https://registry.npmjs.org/@nivo/legends/-/legends-0.80.0.tgz",
-      "integrity": "sha512-h0IUIPGygpbKIZZZWIxkkxOw4SO0rqPrqDrykjaoQz4CvL4HtLIUS3YRA4akKOVNZfS5agmImjzvIe0s3RvqlQ==",
+      "version": "0.83.0",
+      "resolved": "https://registry.npmjs.org/@nivo/legends/-/legends-0.83.0.tgz",
+      "integrity": "sha512-WWl3/hTpFJ7/2L0RG53Gbr9KQk+ZjD71a/RIPMJ5ArEvAvKKfWuWQCtEm3FpqAazX8eYMnsQ3Pi17c8ohEIXRg==",
+      "dependencies": {
+        "@nivo/colors": "0.83.0",
+        "@nivo/core": "0.83.0",
+        "@types/d3-scale": "^3.2.3",
+        "@types/prop-types": "^15.7.2",
+        "d3-scale": "^3.2.3",
+        "prop-types": "^15.7.2"
+      },
       "peerDependencies": {
-        "@nivo/core": "0.80.0",
-        "prop-types": ">= 15.5.10 < 16.0.0",
         "react": ">= 16.14.0 < 19.0.0"
       }
     },
     "node_modules/@nivo/recompose": {
-      "version": "0.80.0",
-      "resolved": "https://registry.npmjs.org/@nivo/recompose/-/recompose-0.80.0.tgz",
-      "integrity": "sha512-iL3g7j3nJGD9+mRDbwNwt/IXDXH6E29mhShY1I7SP91xrfusZV9pSFf4EzyYgruNJk/2iqMuaqn+e+TVFra44A==",
-      "peer": true,
+      "version": "0.83.0",
+      "resolved": "https://registry.npmjs.org/@nivo/recompose/-/recompose-0.83.0.tgz",
+      "integrity": "sha512-3cLEoi9ZoE4LTn6B98oUVd0MRAy5bWK7W3yb0u4EkjLoXXCRvUAI08Wr2AAagOzVOg5PmvghIDgvkz1tlFZTGQ==",
       "dependencies": {
+        "@types/prop-types": "^15.7.2",
+        "@types/react-lifecycles-compat": "^3.0.1",
+        "prop-types": "^15.7.2",
         "react-lifecycles-compat": "^3.0.4"
       },
       "peerDependencies": {
@@ -398,25 +421,31 @@
       }
     },
     "node_modules/@nivo/scales": {
-      "version": "0.80.0",
-      "resolved": "https://registry.npmjs.org/@nivo/scales/-/scales-0.80.0.tgz",
-      "integrity": "sha512-4y2pQdCg+f3n4TKXC2tYuq71veZM+xPRQbOTgGYJpuBvMc7pQsXF9T5z7ryeIG9hkpXkrlyjecU6XcAG7tLSNg==",
+      "version": "0.83.0",
+      "resolved": "https://registry.npmjs.org/@nivo/scales/-/scales-0.83.0.tgz",
+      "integrity": "sha512-DZn5IcMJErCURDuQPmYltu6GTPphTDVLMvbeN/Id/VSVbD1uYKvdXPKUNOe/N2IvnE8wjjCPv88DLcRhw6VTVg==",
       "dependencies": {
+        "@types/d3-scale": "^3.2.3",
+        "@types/d3-time": "^1.1.1",
+        "@types/d3-time-format": "^3.0.0",
         "d3-scale": "^3.2.3",
         "d3-time": "^1.0.11",
         "d3-time-format": "^3.0.0",
         "lodash": "^4.17.21"
       }
     },
+    "node_modules/@nivo/scales/node_modules/@types/d3-time-format": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@types/d3-time-format/-/d3-time-format-3.0.1.tgz",
+      "integrity": "sha512-5GIimz5IqaRsdnxs4YlyTZPwAMfALu/wA4jqSiuqgdbCxUZ2WjrnwANqOtoBJQgeaUTdYNfALJO0Yb0YrDqduA=="
+    },
     "node_modules/@nivo/tooltip": {
-      "version": "0.80.0",
-      "resolved": "https://registry.npmjs.org/@nivo/tooltip/-/tooltip-0.80.0.tgz",
-      "integrity": "sha512-qGmrreRwnCsYjn/LAuwBtxBn/tvG8y+rwgd4gkANLBAoXd3bzJyvmkSe+QJPhUG64bq57ibDK+lO2pC48a3/fw==",
+      "version": "0.83.0",
+      "resolved": "https://registry.npmjs.org/@nivo/tooltip/-/tooltip-0.83.0.tgz",
+      "integrity": "sha512-HewujRqZNmcVnAv/LPLVyYwViad+rYTsFMdzLRzuTPq2hju1R+cfxokTomunG8e1SDtUPtULEVXtPg2ATIzNYg==",
       "dependencies": {
-        "@react-spring/web": "9.4.5"
-      },
-      "peerDependencies": {
-        "@nivo/core": "0.80.0"
+        "@nivo/core": "0.83.0",
+        "@react-spring/web": "9.4.5 || ^9.7.2"
       }
     },
     "node_modules/@nodelib/fs.scandir": {
@@ -471,70 +500,70 @@
       }
     },
     "node_modules/@react-spring/animated": {
-      "version": "9.4.5",
-      "resolved": "https://registry.npmjs.org/@react-spring/animated/-/animated-9.4.5.tgz",
-      "integrity": "sha512-KWqrtvJSMx6Fj9nMJkhTwM9r6LIriExDRV6YHZV9HKQsaolUFppgkOXpC+rsL1JEtEvKv6EkLLmSqHTnuYjiIA==",
+      "version": "9.7.2",
+      "resolved": "https://registry.npmjs.org/@react-spring/animated/-/animated-9.7.2.tgz",
+      "integrity": "sha512-ipvleJ99ipqlnHkz5qhSsgf/ny5aW0ZG8Q+/2Oj9cI7LCc7COdnrSO6V/v8MAX3JOoQNzfz6dye2s5Pt5jGaIA==",
       "dependencies": {
-        "@react-spring/shared": "~9.4.5",
-        "@react-spring/types": "~9.4.5"
+        "@react-spring/shared": "~9.7.2",
+        "@react-spring/types": "~9.7.2"
       },
       "peerDependencies": {
-        "react": "^16.8.0  || >=17.0.0 || >=18.0.0"
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
       }
     },
     "node_modules/@react-spring/core": {
-      "version": "9.4.5",
-      "resolved": "https://registry.npmjs.org/@react-spring/core/-/core-9.4.5.tgz",
-      "integrity": "sha512-83u3FzfQmGMJFwZLAJSwF24/ZJctwUkWtyPD7KYtNagrFeQKUH1I05ZuhmCmqW+2w1KDW1SFWQ43RawqfXKiiQ==",
+      "version": "9.7.2",
+      "resolved": "https://registry.npmjs.org/@react-spring/core/-/core-9.7.2.tgz",
+      "integrity": "sha512-fF512edZT/gKVCA90ZRxfw1DmELeVwiL4OC2J6bMUlNr707C0h4QRoec6DjzG27uLX2MvS1CEatf9KRjwZR9/w==",
       "dependencies": {
-        "@react-spring/animated": "~9.4.5",
-        "@react-spring/rafz": "~9.4.5",
-        "@react-spring/shared": "~9.4.5",
-        "@react-spring/types": "~9.4.5"
+        "@react-spring/animated": "~9.7.2",
+        "@react-spring/rafz": "~9.7.2",
+        "@react-spring/shared": "~9.7.2",
+        "@react-spring/types": "~9.7.2"
       },
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/react-spring/donate"
       },
       "peerDependencies": {
-        "react": "^16.8.0  || >=17.0.0 || >=18.0.0"
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
       }
     },
     "node_modules/@react-spring/rafz": {
-      "version": "9.4.5",
-      "resolved": "https://registry.npmjs.org/@react-spring/rafz/-/rafz-9.4.5.tgz",
-      "integrity": "sha512-swGsutMwvnoyTRxvqhfJBtGM8Ipx6ks0RkIpNX9F/U7XmyPvBMGd3GgX/mqxZUpdlsuI1zr/jiYw+GXZxAlLcQ=="
+      "version": "9.7.2",
+      "resolved": "https://registry.npmjs.org/@react-spring/rafz/-/rafz-9.7.2.tgz",
+      "integrity": "sha512-kDWMYDQto3+flkrX3vy6DU/l9pxQ4TVW91DglQEc11iDc7shF4+WVDRJvOVLX+xoMP7zyag1dMvlIgvQ+dvA/A=="
     },
     "node_modules/@react-spring/shared": {
-      "version": "9.4.5",
-      "resolved": "https://registry.npmjs.org/@react-spring/shared/-/shared-9.4.5.tgz",
-      "integrity": "sha512-JhMh3nFKsqyag0KM5IIM8BQANGscTdd0mMv3BXsUiMZrcjQTskyfnv5qxEeGWbJGGar52qr5kHuBHtCjQOzniA==",
+      "version": "9.7.2",
+      "resolved": "https://registry.npmjs.org/@react-spring/shared/-/shared-9.7.2.tgz",
+      "integrity": "sha512-6U9qkno+9DxlH5nSltnPs+kU6tYKf0bPLURX2te13aGel8YqgcpFYp5Av8DcN2x3sukinAsmzHUS/FRsdZMMBA==",
       "dependencies": {
-        "@react-spring/rafz": "~9.4.5",
-        "@react-spring/types": "~9.4.5"
+        "@react-spring/rafz": "~9.7.2",
+        "@react-spring/types": "~9.7.2"
       },
       "peerDependencies": {
-        "react": "^16.8.0  || >=17.0.0 || >=18.0.0"
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
       }
     },
     "node_modules/@react-spring/types": {
-      "version": "9.4.5",
-      "resolved": "https://registry.npmjs.org/@react-spring/types/-/types-9.4.5.tgz",
-      "integrity": "sha512-mpRIamoHwql0ogxEUh9yr4TP0xU5CWyZxVQeccGkHHF8kPMErtDXJlxyo0lj+telRF35XNihtPTWoflqtyARmg=="
+      "version": "9.7.2",
+      "resolved": "https://registry.npmjs.org/@react-spring/types/-/types-9.7.2.tgz",
+      "integrity": "sha512-GEflx2Ex/TKVMHq5g5MxQDNNPNhqg+4Db9m7+vGTm8ttZiyga7YQUF24shgRNebKIjahqCuei16SZga8h1pe4g=="
     },
     "node_modules/@react-spring/web": {
-      "version": "9.4.5",
-      "resolved": "https://registry.npmjs.org/@react-spring/web/-/web-9.4.5.tgz",
-      "integrity": "sha512-NGAkOtKmOzDEctL7MzRlQGv24sRce++0xAY7KlcxmeVkR7LRSGkoXHaIfm9ObzxPMcPHQYQhf3+X9jepIFNHQA==",
+      "version": "9.7.2",
+      "resolved": "https://registry.npmjs.org/@react-spring/web/-/web-9.7.2.tgz",
+      "integrity": "sha512-7qNc7/5KShu2D05x7o2Ols2nUE7mCKfKLaY2Ix70xPMfTle1sZisoQMBFgV9w/fSLZlHZHV9P0uWJqEXQnbV4Q==",
       "dependencies": {
-        "@react-spring/animated": "~9.4.5",
-        "@react-spring/core": "~9.4.5",
-        "@react-spring/shared": "~9.4.5",
-        "@react-spring/types": "~9.4.5"
+        "@react-spring/animated": "~9.7.2",
+        "@react-spring/core": "~9.7.2",
+        "@react-spring/shared": "~9.7.2",
+        "@react-spring/types": "~9.7.2"
       },
       "peerDependencies": {
-        "react": "^16.8.0  || >=17.0.0 || >=18.0.0",
-        "react-dom": "^16.8.0  || >=17.0.0 || >=18.0.0"
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0"
       }
     },
     "node_modules/@rushstack/eslint-patch": {
@@ -550,10 +579,89 @@
         "tslib": "^2.4.0"
       }
     },
+    "node_modules/@types/d3-color": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@types/d3-color/-/d3-color-2.0.3.tgz",
+      "integrity": "sha512-+0EtEjBfKEDtH9Rk3u3kLOUXM5F+iZK+WvASPb0MhIZl8J8NUvGeZRwKCXl+P3HkYx5TdU4YtcibpqHkSR9n7w=="
+    },
+    "node_modules/@types/d3-format": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-format/-/d3-format-1.4.2.tgz",
+      "integrity": "sha512-WeGCHAs7PHdZYq6lwl/+jsl+Nfc1J2W1kNcMeIMYzQsT6mtBDBgtJ/rcdjZ0k0rVIvqEZqhhuD5TK/v3P2gFHQ=="
+    },
+    "node_modules/@types/d3-path": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-path/-/d3-path-2.0.2.tgz",
+      "integrity": "sha512-3YHpvDw9LzONaJzejXLOwZ3LqwwkoXb9LI2YN7Hbd6pkGo5nIlJ09ul4bQhBN4hQZJKmUpX8HkVqbzgUKY48cg=="
+    },
+    "node_modules/@types/d3-scale": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-scale/-/d3-scale-3.3.2.tgz",
+      "integrity": "sha512-gGqr7x1ost9px3FvIfUMi5XA/F/yAf4UkUDtdQhpH92XCT0Oa7zkkRzY61gPVJq+DxpHn/btouw5ohWkbBsCzQ==",
+      "dependencies": {
+        "@types/d3-time": "^2"
+      }
+    },
+    "node_modules/@types/d3-scale-chromatic": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@types/d3-scale-chromatic/-/d3-scale-chromatic-2.0.1.tgz",
+      "integrity": "sha512-3EuZlbPu+pvclZcb1DhlymTWT2W+lYsRKBjvkH2ojDbCWDYavifqu1vYX9WGzlPgCgcS4Alhk1+zapXbGEGylQ=="
+    },
+    "node_modules/@types/d3-scale/node_modules/@types/d3-time": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@types/d3-time/-/d3-time-2.1.1.tgz",
+      "integrity": "sha512-9MVYlmIgmRR31C5b4FVSWtuMmBHh2mOWQYfl7XAYOa8dsnb7iEmUmRSWSFgXFtkjxO65d7hTUHQC+RhR/9IWFg=="
+    },
+    "node_modules/@types/d3-shape": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/@types/d3-shape/-/d3-shape-2.1.3.tgz",
+      "integrity": "sha512-HAhCel3wP93kh4/rq+7atLdybcESZ5bRHDEZUojClyZWsRuEMo3A52NGYJSh48SxfxEU6RZIVbZL2YFZ2OAlzQ==",
+      "dependencies": {
+        "@types/d3-path": "^2"
+      }
+    },
+    "node_modules/@types/d3-time": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@types/d3-time/-/d3-time-1.1.1.tgz",
+      "integrity": "sha512-ULX7LoqXTCYtM+tLYOaeAJK7IwCT+4Gxlm2MaH0ErKLi07R5lh8NHCAyWcDkCCmx1AfRcBEV6H9QE9R25uP7jw=="
+    },
+    "node_modules/@types/d3-time-format": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/@types/d3-time-format/-/d3-time-format-2.3.1.tgz",
+      "integrity": "sha512-fck0Z9RGfIQn3GJIEKVrp15h9m6Vlg0d5XXeiE/6+CQiBmMDZxfR21XtjEPuDeg7gC3bBM0SdieA5XF3GW1wKA=="
+    },
     "node_modules/@types/json5": {
       "version": "0.0.29",
       "resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
       "integrity": "sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ=="
+    },
+    "node_modules/@types/prop-types": {
+      "version": "15.7.5",
+      "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.5.tgz",
+      "integrity": "sha512-JCB8C6SnDoQf0cNycqd/35A7MjcnK+ZTqE7judS6o7utxUCg6imJg3QK2qzHKszlTjcj2cn+NwMB2i96ubpj7w=="
+    },
+    "node_modules/@types/react": {
+      "version": "18.2.6",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.2.6.tgz",
+      "integrity": "sha512-wRZClXn//zxCFW+ye/D2qY65UsYP1Fpex2YXorHc8awoNamkMZSvBxwxdYVInsHOZZd2Ppq8isnSzJL5Mpf8OA==",
+      "dependencies": {
+        "@types/prop-types": "*",
+        "@types/scheduler": "*",
+        "csstype": "^3.0.2"
+      }
+    },
+    "node_modules/@types/react-lifecycles-compat": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@types/react-lifecycles-compat/-/react-lifecycles-compat-3.0.1.tgz",
+      "integrity": "sha512-4KiU5s1Go4xRbf7t6VxUUpBeN5PGjpjpBv9VvET4uiPHC500VNYBclU13f8ehHkHoZL39b2cfwHu6RzbV3b44A==",
+      "dependencies": {
+        "@types/react": "*"
+      }
+    },
+    "node_modules/@types/scheduler": {
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@types/scheduler/-/scheduler-0.16.3.tgz",
+      "integrity": "sha512-5cJ8CB4yAx7BH1oMvdU0Jh9lrEXyPkar6F9G/ERswkCuvP4KQZfZkSjcMbAICCpQTN4OuZn8tz0HiKv9TGZgrQ=="
     },
     "node_modules/@typescript-eslint/parser": {
       "version": "5.59.2",
@@ -1034,6 +1142,11 @@
         "node": ">= 8"
       }
     },
+    "node_modules/csstype": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.2.tgz",
+      "integrity": "sha512-I7K1Uu0MBPzaFKg4nI5Q7Vs2t+3gWWW648spaF+Rg7pI9ds18Ugn+lvg4SHczUdKlHI5LWBXyqfS8+DufyBsgQ=="
+    },
     "node_modules/d3-array": {
       "version": "2.12.1",
       "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-2.12.1.tgz",
@@ -1043,9 +1156,12 @@
       }
     },
     "node_modules/d3-color": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-2.0.0.tgz",
-      "integrity": "sha512-SPXi0TSKPD4g9tw0NMZFnR95XVgUZiBH+uUTqQuDu1OsE2zomHU7ho0FISciaPvosimixwHFl3WHLGabv6dDgQ=="
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-3.1.0.tgz",
+      "integrity": "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==",
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/d3-format": {
       "version": "1.4.5",
@@ -1059,6 +1175,11 @@
       "dependencies": {
         "d3-color": "1 - 2"
       }
+    },
+    "node_modules/d3-interpolate/node_modules/d3-color": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-2.0.0.tgz",
+      "integrity": "sha512-SPXi0TSKPD4g9tw0NMZFnR95XVgUZiBH+uUTqQuDu1OsE2zomHU7ho0FISciaPvosimixwHFl3WHLGabv6dDgQ=="
     },
     "node_modules/d3-path": {
       "version": "1.0.9",
@@ -1085,6 +1206,11 @@
         "d3-color": "1 - 2",
         "d3-interpolate": "1 - 2"
       }
+    },
+    "node_modules/d3-scale-chromatic/node_modules/d3-color": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-2.0.0.tgz",
+      "integrity": "sha512-SPXi0TSKPD4g9tw0NMZFnR95XVgUZiBH+uUTqQuDu1OsE2zomHU7ho0FISciaPvosimixwHFl3WHLGabv6dDgQ=="
     },
     "node_modules/d3-scale/node_modules/d3-time": {
       "version": "2.1.1",
@@ -3332,8 +3458,7 @@
     "node_modules/react-lifecycles-compat": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz",
-      "integrity": "sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA==",
-      "peer": true
+      "integrity": "sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA=="
     },
     "node_modules/regenerator-runtime": {
       "version": "0.13.11",
@@ -4127,63 +4252,81 @@
       "optional": true
     },
     "@nivo/annotations": {
-      "version": "0.80.0",
-      "resolved": "https://registry.npmjs.org/@nivo/annotations/-/annotations-0.80.0.tgz",
-      "integrity": "sha512-bC9z0CLjU07LULTMWsqpjovRtHxP7n8oJjqBQBLmHOGB4IfiLbrryBfu9+aEZH3VN2jXHhdpWUz+HxeZzOzsLg==",
+      "version": "0.83.0",
+      "resolved": "https://registry.npmjs.org/@nivo/annotations/-/annotations-0.83.0.tgz",
+      "integrity": "sha512-FkfCprk1a3WCCNcQOfI2+Ww7vqTP/nJjQDVhFYf1YAaEGwXi4+OO4uJAtKtNcGE5cJWdOp+f0Gt4aNPGx7RtEw==",
       "requires": {
-        "@nivo/colors": "0.80.0",
-        "@react-spring/web": "9.4.5",
-        "lodash": "^4.17.21"
+        "@nivo/colors": "0.83.0",
+        "@nivo/core": "0.83.0",
+        "@react-spring/web": "9.4.5 || ^9.7.2",
+        "@types/prop-types": "^15.7.2",
+        "lodash": "^4.17.21",
+        "prop-types": "^15.7.2"
       }
     },
     "@nivo/axes": {
-      "version": "0.80.0",
-      "resolved": "https://registry.npmjs.org/@nivo/axes/-/axes-0.80.0.tgz",
-      "integrity": "sha512-AsUyaSHGwQVSEK8QXpsn8X+poZxvakLMYW7crKY1xTGPNw+SU4SSBohPVumm2jMH3fTSLNxLhAjWo71GBJXfdA==",
+      "version": "0.83.0",
+      "resolved": "https://registry.npmjs.org/@nivo/axes/-/axes-0.83.0.tgz",
+      "integrity": "sha512-rHMl+DdXQlY2wl7VCSQNcJi4QNISUWOkcWzJeJeVaYR73Z13SVGgiC7kW0czJuogDTSnDAJ/EcFCGmyGVuznGQ==",
       "requires": {
-        "@nivo/scales": "0.80.0",
-        "@react-spring/web": "9.4.5",
+        "@nivo/core": "0.83.0",
+        "@nivo/scales": "0.83.0",
+        "@react-spring/web": "9.4.5 || ^9.7.2",
+        "@types/d3-format": "^1.4.1",
+        "@types/d3-time-format": "^2.3.1",
+        "@types/prop-types": "^15.7.2",
         "d3-format": "^1.4.4",
-        "d3-time-format": "^3.0.0"
+        "d3-time-format": "^3.0.0",
+        "prop-types": "^15.7.2"
       }
     },
     "@nivo/bar": {
-      "version": "0.80.0",
-      "resolved": "https://registry.npmjs.org/@nivo/bar/-/bar-0.80.0.tgz",
-      "integrity": "sha512-woE/S12Sp+RKQeOHtp302WXfy5usj73cV/gjP95PzJxMv+Rn01i1Uwys3BILzc9h4+OxYuWTFqLADAySAmi7qQ==",
+      "version": "0.83.0",
+      "resolved": "https://registry.npmjs.org/@nivo/bar/-/bar-0.83.0.tgz",
+      "integrity": "sha512-QXN6BcT1PiT/YViyoDU4G5mytbOUP1jYbuQmJhDDxKPMLNcZ/pHfThedRGVfDoD1poHBRJtV6mbgeCpAVmlTtw==",
       "requires": {
-        "@nivo/annotations": "0.80.0",
-        "@nivo/axes": "0.80.0",
-        "@nivo/colors": "0.80.0",
-        "@nivo/legends": "0.80.0",
-        "@nivo/scales": "0.80.0",
-        "@nivo/tooltip": "0.80.0",
-        "@react-spring/web": "9.4.5",
+        "@nivo/annotations": "0.83.0",
+        "@nivo/axes": "0.83.0",
+        "@nivo/colors": "0.83.0",
+        "@nivo/core": "0.83.0",
+        "@nivo/legends": "0.83.0",
+        "@nivo/scales": "0.83.0",
+        "@nivo/tooltip": "0.83.0",
+        "@react-spring/web": "9.4.5 || ^9.7.2",
+        "@types/d3-scale": "^3.2.3",
+        "@types/d3-shape": "^2.0.0",
         "d3-scale": "^3.2.3",
         "d3-shape": "^1.3.5",
         "lodash": "^4.17.21"
       }
     },
     "@nivo/colors": {
-      "version": "0.80.0",
-      "resolved": "https://registry.npmjs.org/@nivo/colors/-/colors-0.80.0.tgz",
-      "integrity": "sha512-T695Zr411FU4RPo7WDINOAn8f79DPP10SFJmDdEqELE+cbzYVTpXqLGZ7JMv88ko7EOf9qxLQgcBqY69rp9tHQ==",
+      "version": "0.83.0",
+      "resolved": "https://registry.npmjs.org/@nivo/colors/-/colors-0.83.0.tgz",
+      "integrity": "sha512-n34LWYtE2hbd1fdCDP7TCHNZdbiO1PwcvXLo0VsKK5lNPY/FA5SXA7Z9Ubl/ChSwBwbzAsaAhjTy8KzKzSjDcA==",
       "requires": {
-        "d3-color": "^2.0.0",
+        "@nivo/core": "0.83.0",
+        "@types/d3-color": "^2.0.0",
+        "@types/d3-scale": "^3.2.3",
+        "@types/d3-scale-chromatic": "^2.0.0",
+        "@types/prop-types": "^15.7.2",
+        "d3-color": "^3.1.0",
         "d3-scale": "^3.2.3",
         "d3-scale-chromatic": "^2.0.0",
-        "lodash": "^4.17.21"
+        "lodash": "^4.17.21",
+        "prop-types": "^15.7.2"
       }
     },
     "@nivo/core": {
-      "version": "0.80.0",
-      "resolved": "https://registry.npmjs.org/@nivo/core/-/core-0.80.0.tgz",
-      "integrity": "sha512-6caih0RavXdWWSfde+rC2pk17WrX9YQlqK26BrxIdXzv3Ydzlh5SkrC7dR2TEvMGBhunzVeLOfiC2DWT1S8CFg==",
-      "peer": true,
+      "version": "0.83.0",
+      "resolved": "https://registry.npmjs.org/@nivo/core/-/core-0.83.0.tgz",
+      "integrity": "sha512-I9fjZAbIPz41JA2WP8Avsud/xk0iiM1nWUzcvZBDebBGFDB5Y1lrldUt9l5kvOeMth3Qj/1lVFTiJxQuojxH4Q==",
       "requires": {
-        "@nivo/recompose": "0.80.0",
-        "@react-spring/web": "9.4.5",
-        "d3-color": "^2.0.0",
+        "@nivo/recompose": "0.83.0",
+        "@nivo/tooltip": "0.83.0",
+        "@react-spring/web": "9.4.5 || ^9.7.2",
+        "@types/d3-shape": "^2.0.0",
+        "d3-color": "^3.1.0",
         "d3-format": "^1.4.4",
         "d3-interpolate": "^2.0.1",
         "d3-scale": "^3.2.3",
@@ -4194,37 +4337,57 @@
       }
     },
     "@nivo/legends": {
-      "version": "0.80.0",
-      "resolved": "https://registry.npmjs.org/@nivo/legends/-/legends-0.80.0.tgz",
-      "integrity": "sha512-h0IUIPGygpbKIZZZWIxkkxOw4SO0rqPrqDrykjaoQz4CvL4HtLIUS3YRA4akKOVNZfS5agmImjzvIe0s3RvqlQ==",
-      "requires": {}
+      "version": "0.83.0",
+      "resolved": "https://registry.npmjs.org/@nivo/legends/-/legends-0.83.0.tgz",
+      "integrity": "sha512-WWl3/hTpFJ7/2L0RG53Gbr9KQk+ZjD71a/RIPMJ5ArEvAvKKfWuWQCtEm3FpqAazX8eYMnsQ3Pi17c8ohEIXRg==",
+      "requires": {
+        "@nivo/colors": "0.83.0",
+        "@nivo/core": "0.83.0",
+        "@types/d3-scale": "^3.2.3",
+        "@types/prop-types": "^15.7.2",
+        "d3-scale": "^3.2.3",
+        "prop-types": "^15.7.2"
+      }
     },
     "@nivo/recompose": {
-      "version": "0.80.0",
-      "resolved": "https://registry.npmjs.org/@nivo/recompose/-/recompose-0.80.0.tgz",
-      "integrity": "sha512-iL3g7j3nJGD9+mRDbwNwt/IXDXH6E29mhShY1I7SP91xrfusZV9pSFf4EzyYgruNJk/2iqMuaqn+e+TVFra44A==",
-      "peer": true,
+      "version": "0.83.0",
+      "resolved": "https://registry.npmjs.org/@nivo/recompose/-/recompose-0.83.0.tgz",
+      "integrity": "sha512-3cLEoi9ZoE4LTn6B98oUVd0MRAy5bWK7W3yb0u4EkjLoXXCRvUAI08Wr2AAagOzVOg5PmvghIDgvkz1tlFZTGQ==",
       "requires": {
+        "@types/prop-types": "^15.7.2",
+        "@types/react-lifecycles-compat": "^3.0.1",
+        "prop-types": "^15.7.2",
         "react-lifecycles-compat": "^3.0.4"
       }
     },
     "@nivo/scales": {
-      "version": "0.80.0",
-      "resolved": "https://registry.npmjs.org/@nivo/scales/-/scales-0.80.0.tgz",
-      "integrity": "sha512-4y2pQdCg+f3n4TKXC2tYuq71veZM+xPRQbOTgGYJpuBvMc7pQsXF9T5z7ryeIG9hkpXkrlyjecU6XcAG7tLSNg==",
+      "version": "0.83.0",
+      "resolved": "https://registry.npmjs.org/@nivo/scales/-/scales-0.83.0.tgz",
+      "integrity": "sha512-DZn5IcMJErCURDuQPmYltu6GTPphTDVLMvbeN/Id/VSVbD1uYKvdXPKUNOe/N2IvnE8wjjCPv88DLcRhw6VTVg==",
       "requires": {
+        "@types/d3-scale": "^3.2.3",
+        "@types/d3-time": "^1.1.1",
+        "@types/d3-time-format": "^3.0.0",
         "d3-scale": "^3.2.3",
         "d3-time": "^1.0.11",
         "d3-time-format": "^3.0.0",
         "lodash": "^4.17.21"
+      },
+      "dependencies": {
+        "@types/d3-time-format": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/@types/d3-time-format/-/d3-time-format-3.0.1.tgz",
+          "integrity": "sha512-5GIimz5IqaRsdnxs4YlyTZPwAMfALu/wA4jqSiuqgdbCxUZ2WjrnwANqOtoBJQgeaUTdYNfALJO0Yb0YrDqduA=="
+        }
       }
     },
     "@nivo/tooltip": {
-      "version": "0.80.0",
-      "resolved": "https://registry.npmjs.org/@nivo/tooltip/-/tooltip-0.80.0.tgz",
-      "integrity": "sha512-qGmrreRwnCsYjn/LAuwBtxBn/tvG8y+rwgd4gkANLBAoXd3bzJyvmkSe+QJPhUG64bq57ibDK+lO2pC48a3/fw==",
+      "version": "0.83.0",
+      "resolved": "https://registry.npmjs.org/@nivo/tooltip/-/tooltip-0.83.0.tgz",
+      "integrity": "sha512-HewujRqZNmcVnAv/LPLVyYwViad+rYTsFMdzLRzuTPq2hju1R+cfxokTomunG8e1SDtUPtULEVXtPg2ATIzNYg==",
       "requires": {
-        "@react-spring/web": "9.4.5"
+        "@nivo/core": "0.83.0",
+        "@react-spring/web": "9.4.5 || ^9.7.2"
       }
     },
     "@nodelib/fs.scandir": {
@@ -4264,53 +4427,53 @@
       }
     },
     "@react-spring/animated": {
-      "version": "9.4.5",
-      "resolved": "https://registry.npmjs.org/@react-spring/animated/-/animated-9.4.5.tgz",
-      "integrity": "sha512-KWqrtvJSMx6Fj9nMJkhTwM9r6LIriExDRV6YHZV9HKQsaolUFppgkOXpC+rsL1JEtEvKv6EkLLmSqHTnuYjiIA==",
+      "version": "9.7.2",
+      "resolved": "https://registry.npmjs.org/@react-spring/animated/-/animated-9.7.2.tgz",
+      "integrity": "sha512-ipvleJ99ipqlnHkz5qhSsgf/ny5aW0ZG8Q+/2Oj9cI7LCc7COdnrSO6V/v8MAX3JOoQNzfz6dye2s5Pt5jGaIA==",
       "requires": {
-        "@react-spring/shared": "~9.4.5",
-        "@react-spring/types": "~9.4.5"
+        "@react-spring/shared": "~9.7.2",
+        "@react-spring/types": "~9.7.2"
       }
     },
     "@react-spring/core": {
-      "version": "9.4.5",
-      "resolved": "https://registry.npmjs.org/@react-spring/core/-/core-9.4.5.tgz",
-      "integrity": "sha512-83u3FzfQmGMJFwZLAJSwF24/ZJctwUkWtyPD7KYtNagrFeQKUH1I05ZuhmCmqW+2w1KDW1SFWQ43RawqfXKiiQ==",
+      "version": "9.7.2",
+      "resolved": "https://registry.npmjs.org/@react-spring/core/-/core-9.7.2.tgz",
+      "integrity": "sha512-fF512edZT/gKVCA90ZRxfw1DmELeVwiL4OC2J6bMUlNr707C0h4QRoec6DjzG27uLX2MvS1CEatf9KRjwZR9/w==",
       "requires": {
-        "@react-spring/animated": "~9.4.5",
-        "@react-spring/rafz": "~9.4.5",
-        "@react-spring/shared": "~9.4.5",
-        "@react-spring/types": "~9.4.5"
+        "@react-spring/animated": "~9.7.2",
+        "@react-spring/rafz": "~9.7.2",
+        "@react-spring/shared": "~9.7.2",
+        "@react-spring/types": "~9.7.2"
       }
     },
     "@react-spring/rafz": {
-      "version": "9.4.5",
-      "resolved": "https://registry.npmjs.org/@react-spring/rafz/-/rafz-9.4.5.tgz",
-      "integrity": "sha512-swGsutMwvnoyTRxvqhfJBtGM8Ipx6ks0RkIpNX9F/U7XmyPvBMGd3GgX/mqxZUpdlsuI1zr/jiYw+GXZxAlLcQ=="
+      "version": "9.7.2",
+      "resolved": "https://registry.npmjs.org/@react-spring/rafz/-/rafz-9.7.2.tgz",
+      "integrity": "sha512-kDWMYDQto3+flkrX3vy6DU/l9pxQ4TVW91DglQEc11iDc7shF4+WVDRJvOVLX+xoMP7zyag1dMvlIgvQ+dvA/A=="
     },
     "@react-spring/shared": {
-      "version": "9.4.5",
-      "resolved": "https://registry.npmjs.org/@react-spring/shared/-/shared-9.4.5.tgz",
-      "integrity": "sha512-JhMh3nFKsqyag0KM5IIM8BQANGscTdd0mMv3BXsUiMZrcjQTskyfnv5qxEeGWbJGGar52qr5kHuBHtCjQOzniA==",
+      "version": "9.7.2",
+      "resolved": "https://registry.npmjs.org/@react-spring/shared/-/shared-9.7.2.tgz",
+      "integrity": "sha512-6U9qkno+9DxlH5nSltnPs+kU6tYKf0bPLURX2te13aGel8YqgcpFYp5Av8DcN2x3sukinAsmzHUS/FRsdZMMBA==",
       "requires": {
-        "@react-spring/rafz": "~9.4.5",
-        "@react-spring/types": "~9.4.5"
+        "@react-spring/rafz": "~9.7.2",
+        "@react-spring/types": "~9.7.2"
       }
     },
     "@react-spring/types": {
-      "version": "9.4.5",
-      "resolved": "https://registry.npmjs.org/@react-spring/types/-/types-9.4.5.tgz",
-      "integrity": "sha512-mpRIamoHwql0ogxEUh9yr4TP0xU5CWyZxVQeccGkHHF8kPMErtDXJlxyo0lj+telRF35XNihtPTWoflqtyARmg=="
+      "version": "9.7.2",
+      "resolved": "https://registry.npmjs.org/@react-spring/types/-/types-9.7.2.tgz",
+      "integrity": "sha512-GEflx2Ex/TKVMHq5g5MxQDNNPNhqg+4Db9m7+vGTm8ttZiyga7YQUF24shgRNebKIjahqCuei16SZga8h1pe4g=="
     },
     "@react-spring/web": {
-      "version": "9.4.5",
-      "resolved": "https://registry.npmjs.org/@react-spring/web/-/web-9.4.5.tgz",
-      "integrity": "sha512-NGAkOtKmOzDEctL7MzRlQGv24sRce++0xAY7KlcxmeVkR7LRSGkoXHaIfm9ObzxPMcPHQYQhf3+X9jepIFNHQA==",
+      "version": "9.7.2",
+      "resolved": "https://registry.npmjs.org/@react-spring/web/-/web-9.7.2.tgz",
+      "integrity": "sha512-7qNc7/5KShu2D05x7o2Ols2nUE7mCKfKLaY2Ix70xPMfTle1sZisoQMBFgV9w/fSLZlHZHV9P0uWJqEXQnbV4Q==",
       "requires": {
-        "@react-spring/animated": "~9.4.5",
-        "@react-spring/core": "~9.4.5",
-        "@react-spring/shared": "~9.4.5",
-        "@react-spring/types": "~9.4.5"
+        "@react-spring/animated": "~9.7.2",
+        "@react-spring/core": "~9.7.2",
+        "@react-spring/shared": "~9.7.2",
+        "@react-spring/types": "~9.7.2"
       }
     },
     "@rushstack/eslint-patch": {
@@ -4326,10 +4489,91 @@
         "tslib": "^2.4.0"
       }
     },
+    "@types/d3-color": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@types/d3-color/-/d3-color-2.0.3.tgz",
+      "integrity": "sha512-+0EtEjBfKEDtH9Rk3u3kLOUXM5F+iZK+WvASPb0MhIZl8J8NUvGeZRwKCXl+P3HkYx5TdU4YtcibpqHkSR9n7w=="
+    },
+    "@types/d3-format": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-format/-/d3-format-1.4.2.tgz",
+      "integrity": "sha512-WeGCHAs7PHdZYq6lwl/+jsl+Nfc1J2W1kNcMeIMYzQsT6mtBDBgtJ/rcdjZ0k0rVIvqEZqhhuD5TK/v3P2gFHQ=="
+    },
+    "@types/d3-path": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-path/-/d3-path-2.0.2.tgz",
+      "integrity": "sha512-3YHpvDw9LzONaJzejXLOwZ3LqwwkoXb9LI2YN7Hbd6pkGo5nIlJ09ul4bQhBN4hQZJKmUpX8HkVqbzgUKY48cg=="
+    },
+    "@types/d3-scale": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-scale/-/d3-scale-3.3.2.tgz",
+      "integrity": "sha512-gGqr7x1ost9px3FvIfUMi5XA/F/yAf4UkUDtdQhpH92XCT0Oa7zkkRzY61gPVJq+DxpHn/btouw5ohWkbBsCzQ==",
+      "requires": {
+        "@types/d3-time": "^2"
+      },
+      "dependencies": {
+        "@types/d3-time": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/@types/d3-time/-/d3-time-2.1.1.tgz",
+          "integrity": "sha512-9MVYlmIgmRR31C5b4FVSWtuMmBHh2mOWQYfl7XAYOa8dsnb7iEmUmRSWSFgXFtkjxO65d7hTUHQC+RhR/9IWFg=="
+        }
+      }
+    },
+    "@types/d3-scale-chromatic": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@types/d3-scale-chromatic/-/d3-scale-chromatic-2.0.1.tgz",
+      "integrity": "sha512-3EuZlbPu+pvclZcb1DhlymTWT2W+lYsRKBjvkH2ojDbCWDYavifqu1vYX9WGzlPgCgcS4Alhk1+zapXbGEGylQ=="
+    },
+    "@types/d3-shape": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/@types/d3-shape/-/d3-shape-2.1.3.tgz",
+      "integrity": "sha512-HAhCel3wP93kh4/rq+7atLdybcESZ5bRHDEZUojClyZWsRuEMo3A52NGYJSh48SxfxEU6RZIVbZL2YFZ2OAlzQ==",
+      "requires": {
+        "@types/d3-path": "^2"
+      }
+    },
+    "@types/d3-time": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@types/d3-time/-/d3-time-1.1.1.tgz",
+      "integrity": "sha512-ULX7LoqXTCYtM+tLYOaeAJK7IwCT+4Gxlm2MaH0ErKLi07R5lh8NHCAyWcDkCCmx1AfRcBEV6H9QE9R25uP7jw=="
+    },
+    "@types/d3-time-format": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/@types/d3-time-format/-/d3-time-format-2.3.1.tgz",
+      "integrity": "sha512-fck0Z9RGfIQn3GJIEKVrp15h9m6Vlg0d5XXeiE/6+CQiBmMDZxfR21XtjEPuDeg7gC3bBM0SdieA5XF3GW1wKA=="
+    },
     "@types/json5": {
       "version": "0.0.29",
       "resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
       "integrity": "sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ=="
+    },
+    "@types/prop-types": {
+      "version": "15.7.5",
+      "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.5.tgz",
+      "integrity": "sha512-JCB8C6SnDoQf0cNycqd/35A7MjcnK+ZTqE7judS6o7utxUCg6imJg3QK2qzHKszlTjcj2cn+NwMB2i96ubpj7w=="
+    },
+    "@types/react": {
+      "version": "18.2.6",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.2.6.tgz",
+      "integrity": "sha512-wRZClXn//zxCFW+ye/D2qY65UsYP1Fpex2YXorHc8awoNamkMZSvBxwxdYVInsHOZZd2Ppq8isnSzJL5Mpf8OA==",
+      "requires": {
+        "@types/prop-types": "*",
+        "@types/scheduler": "*",
+        "csstype": "^3.0.2"
+      }
+    },
+    "@types/react-lifecycles-compat": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@types/react-lifecycles-compat/-/react-lifecycles-compat-3.0.1.tgz",
+      "integrity": "sha512-4KiU5s1Go4xRbf7t6VxUUpBeN5PGjpjpBv9VvET4uiPHC500VNYBclU13f8ehHkHoZL39b2cfwHu6RzbV3b44A==",
+      "requires": {
+        "@types/react": "*"
+      }
+    },
+    "@types/scheduler": {
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@types/scheduler/-/scheduler-0.16.3.tgz",
+      "integrity": "sha512-5cJ8CB4yAx7BH1oMvdU0Jh9lrEXyPkar6F9G/ERswkCuvP4KQZfZkSjcMbAICCpQTN4OuZn8tz0HiKv9TGZgrQ=="
     },
     "@typescript-eslint/parser": {
       "version": "5.59.2",
@@ -4654,6 +4898,11 @@
         "which": "^2.0.1"
       }
     },
+    "csstype": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.2.tgz",
+      "integrity": "sha512-I7K1Uu0MBPzaFKg4nI5Q7Vs2t+3gWWW648spaF+Rg7pI9ds18Ugn+lvg4SHczUdKlHI5LWBXyqfS8+DufyBsgQ=="
+    },
     "d3-array": {
       "version": "2.12.1",
       "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-2.12.1.tgz",
@@ -4663,9 +4912,9 @@
       }
     },
     "d3-color": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-2.0.0.tgz",
-      "integrity": "sha512-SPXi0TSKPD4g9tw0NMZFnR95XVgUZiBH+uUTqQuDu1OsE2zomHU7ho0FISciaPvosimixwHFl3WHLGabv6dDgQ=="
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-3.1.0.tgz",
+      "integrity": "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA=="
     },
     "d3-format": {
       "version": "1.4.5",
@@ -4678,6 +4927,13 @@
       "integrity": "sha512-c5UhwwTs/yybcmTpAVqwSFl6vrQ8JZJoT5F7xNFK9pymv5C0Ymcc9/LIJHtYIggg/yS9YHw8i8O8tgb9pupjeQ==",
       "requires": {
         "d3-color": "1 - 2"
+      },
+      "dependencies": {
+        "d3-color": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-2.0.0.tgz",
+          "integrity": "sha512-SPXi0TSKPD4g9tw0NMZFnR95XVgUZiBH+uUTqQuDu1OsE2zomHU7ho0FISciaPvosimixwHFl3WHLGabv6dDgQ=="
+        }
       }
     },
     "d3-path": {
@@ -4714,6 +4970,13 @@
       "requires": {
         "d3-color": "1 - 2",
         "d3-interpolate": "1 - 2"
+      },
+      "dependencies": {
+        "d3-color": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-2.0.0.tgz",
+          "integrity": "sha512-SPXi0TSKPD4g9tw0NMZFnR95XVgUZiBH+uUTqQuDu1OsE2zomHU7ho0FISciaPvosimixwHFl3WHLGabv6dDgQ=="
+        }
       }
     },
     "d3-shape": {
@@ -6288,8 +6551,7 @@
     "react-lifecycles-compat": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz",
-      "integrity": "sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA==",
-      "peer": true
+      "integrity": "sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA=="
     },
     "regenerator-runtime": {
       "version": "0.13.11",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   "author": "",
   "license": "MIT",
   "dependencies": {
-    "@nivo/bar": "^0.80.0",
+    "@nivo/bar": "^0.83.0",
     "eslint-config-next": "^13.3.4",
     "iframe-resizer": "^4.3.6",
     "next": "^13.3.1",


### PR DESCRIPTION
## Notes

supersede #55 

La dernière version de nivo semble être problématique et demande de modifier l'utilisation des packages par next : https://github.com/plouc/nivo/issues/1941

Je propose de ne pas merger cette PR avant qu'une prochaine version de nivo soit publiée.

https://www.npmjs.com/package/@nivo/bar?activeTab=versions