### PR TITLE
Fix and Improve Behaviour page

### DIFF
--- a/components/behaviourHeader.js
+++ b/components/behaviourHeader.js
@@ -1,0 +1,17 @@
+import React from "react"
+
+const BehavioursHeader = () => (
+  <>
+    <h2>Comportements utilisateur sur la page de résultats</h2>
+    <div>
+      <p>
+        Les graphiques suivants représentent les taux de conversion sur la page
+        de présentation de résultats sur le simulateur. Différents évènements
+        sont capturés pour mieux évaluer l'impact du simulateur sur le
+        non-recours aux dispositifs présentés aux usagers.
+      </p>
+    </div>
+  </>
+)
+
+export default BehavioursHeader

--- a/components/surveyDetails.js
+++ b/components/surveyDetails.js
@@ -33,19 +33,19 @@ class SurveyDetails extends Component {
   }
 
   async componentDidMount() {
-    const parameters = Url.getParameters(["geographic", "institution"])
+    const parameters = Url.getParameters(["institution_type", "institution"])
     this.filterBenefits(
-      parameters.geographic || "*",
+      parameters.institution_type || "*",
       parameters.institution || "*"
     )
   }
 
-  filterBenefits(geographic = "*", institution = "*") {
+  filterBenefits(institution_type = "*", institution = "*") {
     this.setState(
       DataFilter.benefits(
         this.state.surveyDetails,
         this.state.institutions,
-        geographic,
+        institution_type,
         institution
       ),
       () => this.sortTable("total")

--- a/components/surveyDetails.js
+++ b/components/surveyDetails.js
@@ -69,8 +69,7 @@ class SurveyDetails extends Component {
       this.state.filteredBenefits,
       sortingBy,
       sortAscending,
-      ["id"],
-      ["total", "asked", "failed", "nothing", "already"]
+      ["id"]
     )
 
     this.setState({

--- a/components/surveyDetails.js
+++ b/components/surveyDetails.js
@@ -22,8 +22,8 @@ class SurveyDetails extends Component {
     this.state = {
       surveyDetails: props.survey,
       institutions: props.institutions,
-      currentInstitutionType: "*",
-      currentInstitution: "*",
+      currentInstitutionType: DataFilter.DEFAULT_FILTER_VALUE,
+      currentInstitution: DataFilter.DEFAULT_FILTER_VALUE,
       filteredInstitutions: [],
       filteredBenefits: [],
       sortBy: null,
@@ -34,13 +34,18 @@ class SurveyDetails extends Component {
 
   async componentDidMount() {
     const parameters = Url.getParameters(["institution_type", "institution"])
-    this.filterBenefits(
-      parameters.institution_type || "*",
-      parameters.institution || "*"
-    )
+    const {
+      institution_type = DataFilter.DEFAULT_FILTER_VALUE,
+      institution = DataFilter.DEFAULT_FILTER_VALUE,
+    } = parameters
+
+    this.filterBenefits(institution_type, institution)
   }
 
-  filterBenefits(institution_type = "*", institution = "*") {
+  filterBenefits(
+    institution_type = DataFilter.DEFAULT_FILTER_VALUE,
+    institution = DataFilter.DEFAULT_FILTER_VALUE
+  ) {
     this.setState(
       DataFilter.benefits(
         this.state.surveyDetails,
@@ -99,6 +104,13 @@ class SurveyDetails extends Component {
     })
   }
 
+  displayResetButton() {
+    return (
+      this.state.currentInstitutionType != DataFilter.DEFAULT_FILTER_VALUE ||
+      this.state.currentInstitution != DataFilter.DEFAULT_FILTER_VALUE
+    )
+  }
+
   render() {
     return (
       <div>
@@ -130,7 +142,9 @@ class SurveyDetails extends Component {
                   }
                   value={this.state.currentInstitution}
                 >
-                  <option value="*">Toutes les institutions</option>
+                  <option value="{DataFilter.DEFAULT_FILTER_VALUE}">
+                    Toutes les institutions
+                  </option>
                   {this.state.filteredInstitutions.map((institution) => (
                     <option value={institution} key={institution}>
                       {institution}
@@ -139,8 +153,7 @@ class SurveyDetails extends Component {
                 </select>
               )}
 
-              {(this.state.currentInstitutionType != "*" ||
-                this.state.currentInstitution != "*") && (
+              {this.displayResetButton() && (
                 <input type="reset" onClick={() => this.filterBenefits()} />
               )}
             </div>

--- a/components/undisplayedBenefits.js
+++ b/components/undisplayedBenefits.js
@@ -1,0 +1,14 @@
+import React from "react"
+
+const UndisplayedBenefits = ({ undisplayedBenefits }) => (
+  <>
+    <h2>Liste des aides non-affichées durant cette période</h2>
+    <ul>
+      {undisplayedBenefits.map((benefitName) => (
+        <li key={benefitName}>{benefitName}</li>
+      ))}
+    </ul>
+  </>
+)
+
+export default UndisplayedBenefits

--- a/pages/behaviours.js
+++ b/pages/behaviours.js
@@ -29,6 +29,7 @@ class Behaviours extends Component {
       undisplayedBenefits: [],
       sortBy: null,
       sortAscending: false,
+      loading: true,
     }
   }
 
@@ -37,6 +38,8 @@ class Behaviours extends Component {
   }
 
   async fetchUsersBehavioursData() {
+    this.setState({ loading: true })
+
     let recorderStatistics = await Fetch.getRecorderStatistics(
       periods[this.state.period].from
     )
@@ -311,42 +314,54 @@ class Behaviours extends Component {
               </tr>
             </thead>
             <tbody>
-              {this.state.filteredBenefits.map((benefit) => (
-                <tr key={benefit.id || benefit.label}>
-                  <td data-label="Aide" data-content="aide">
-                    {benefit.id || benefit.label}
+              {this.state.loading && (
+                <tr>
+                  <td
+                    colSpan={Object.keys(EventTypeCategoryMapping).length + 1}
+                  >
+                    <span className="loading">Chargement en cours...</span>
                   </td>
-                  {Object.keys(EventTypeCategoryMapping).map((key) => (
-                    <td
-                      data-label={
-                        EventTypeCategoryMapping[key].name ||
-                        EventTypeCategoryMapping[key].cat
-                      }
-                      data-content={benefit.events[key]}
-                      className="text-right"
-                      key={key}
-                    >
-                      {key === "show" ? (
-                        <>{benefit.events.show}</>
-                      ) : (
-                        <>
-                          <div
-                            className="gauge"
-                            style={{
-                              width: `${benefit.percentageOfEvents[key]}%`,
-                              background: EventTypeCategoryMapping[key].color,
-                            }}
-                          ></div>
-                          {benefit.events[key]}
-                          {benefit.events[key] && (
-                            <small>({benefit.percentageOfEvents[key]}%)</small>
-                          )}
-                        </>
-                      )}
-                    </td>
-                  ))}
                 </tr>
-              ))}
+              )}
+              {!this.state.loading &&
+                this.state.filteredBenefits.map((benefit) => (
+                  <tr key={benefit.id || benefit.label}>
+                    <td data-label="Aide" data-content="aide">
+                      {benefit.id || benefit.label}
+                    </td>
+                    {Object.keys(EventTypeCategoryMapping).map((key) => (
+                      <td
+                        data-label={
+                          EventTypeCategoryMapping[key].name ||
+                          EventTypeCategoryMapping[key].cat
+                        }
+                        data-content={benefit.events[key]}
+                        className="text-right"
+                        key={key}
+                      >
+                        {key === "show" ? (
+                          <>{benefit.events.show}</>
+                        ) : (
+                          <>
+                            <div
+                              className="gauge"
+                              style={{
+                                width: `${benefit.percentageOfEvents[key]}%`,
+                                background: EventTypeCategoryMapping[key].color,
+                              }}
+                            ></div>
+                            {benefit.events[key]}
+                            {benefit.events[key] && (
+                              <small>
+                                ({benefit.percentageOfEvents[key]}%)
+                              </small>
+                            )}
+                          </>
+                        )}
+                      </td>
+                    ))}
+                  </tr>
+                ))}
             </tbody>
           </table>
         </div>

--- a/pages/behaviours.js
+++ b/pages/behaviours.js
@@ -12,6 +12,9 @@ import DataFilter from "../services/dataFilter.js"
 import DateRange from "../services/date.js"
 
 const periods = DateRange.getPeriods()
+const DEFAULT_SORT_BY = "events.show"
+const DEFAULT_SORT_ASCENDING = false
+const ALPHABETICAL_COLUMNS = ["label"]
 
 class Behaviours extends Component {
   constructor(props) {
@@ -87,20 +90,37 @@ class Behaviours extends Component {
       }
     })
 
-    this.setState({
-      benefits: recorderStatistics,
-      filteredBenefits: recorderStatistics,
-      institutions: institutions,
-      undisplayedBenefits,
-    })
-
     const parameters = Url.getParameters(["institution_type", "institution"])
-    this.filterBenefits(
-      parameters.institution_type || DataFilter.DEFAULT_FILTER_VALUE,
-      parameters.institution || DataFilter.DEFAULT_FILTER_VALUE
+
+    const {
+      institution_type,
+      institution,
+    } = parameters
+
+    const filterState = DataFilter.benefits(
+      recorderStatistics,
+      institutions,
+      institution_type || DataFilter.DEFAULT_FILTER_VALUE,
+      institution || DataFilter.DEFAULT_FILTER_VALUE
     )
 
-    this.sortTable("events.show", false)
+    const sortedFilteredBenefits = DataFilter.sort(
+      filterState.filteredBenefits,
+      DEFAULT_SORT_BY,
+      DEFAULT_SORT_ASCENDING,
+      ALPHABETICAL_COLUMNS
+    )
+
+    this.setState({
+      benefits: recorderStatistics,
+      institutions: institutions,
+      undisplayedBenefits,
+      loading: false,
+      ...filterState,
+      filteredBenefits: sortedFilteredBenefits,
+      sortBy: DEFAULT_SORT_BY,
+      sortAscending: DEFAULT_SORT_ASCENDING,
+    })
   }
 
   handlePeriodChange(period) {
@@ -137,10 +157,10 @@ class Behaviours extends Component {
       : this.state.sortAscending
 
     const output = DataFilter.sort(
-      this.state.benefits,
+      this.state.filteredBenefits,
       sortingBy,
       sortAscending,
-      ["label"]
+      ALPHABETICAL_COLUMNS
     )
 
     this.setState({

--- a/pages/behaviours.js
+++ b/pages/behaviours.js
@@ -137,10 +137,7 @@ class Behaviours extends Component {
       this.state.benefits,
       sortingBy,
       sortAscending,
-      ["label"],
-      Object.keys(EventTypeCategoryMapping).map((eventName) =>
-        this.eventSortName(eventName)
-      )
+      ["label"]
     )
 
     this.setState({

--- a/pages/behaviours.js
+++ b/pages/behaviours.js
@@ -1,5 +1,8 @@
 import { Component } from "react"
 
+import BehavioursHeader from "../components/behaviourHeader.js"
+import UndisplayedBenefits from "../components/undisplayedBenefits.js"
+
 import {
   Config,
   EventCategories,
@@ -196,16 +199,7 @@ class Behaviours extends Component {
   render() {
     return (
       <>
-        <h2>Comportements utilisateur sur la page de résultats</h2>
-        <div>
-          <p>
-            Les graphiques suivants représentent les taux de conversion sur la
-            page de présentation de résultats sur le simulateur. Différents
-            évènements sont capturés pour mieux évaluer l'impact du simulateur
-            sur le non-recours aux dispositifs présentés aux usagers.
-          </p>
-        </div>
-
+        <BehavioursHeader />
         <div className="flex-justify">
           <div className="flex-bottom flex-gap">
             <label>
@@ -376,12 +370,9 @@ class Behaviours extends Component {
           )
         })}
 
-        <h2>Liste des aides non-affichées durant cette période</h2>
-        <ul>
-          {this.state.undisplayedBenefits.map((benefitName) => {
-            return <li key={benefitName}>{benefitName}</li>
-          })}
-        </ul>
+        <UndisplayedBenefits
+          undisplayedBenefits={this.state.undisplayedBenefits}
+        />
       </>
     )
   }

--- a/pages/behaviours.js
+++ b/pages/behaviours.js
@@ -107,12 +107,12 @@ class Behaviours extends Component {
     this.setState({ period: period }, this.fetchUsersBehavioursData)
   }
 
-  filterBenefits(geographic = "*", institution = "*") {
+  filterBenefits(institution_type = "*", institution = "*") {
     this.setState(
       DataFilter.benefits(
         this.state.benefits,
         this.state.institutions,
-        geographic,
+        institution_type,
         institution
       )
     )
@@ -196,7 +196,7 @@ class Behaviours extends Component {
 
             {this.state.institutions && (
               <label>
-                <span>Filtrer par géographie</span>
+                <span>Filtrer par type d'institution</span>
                 <br />
                 <select
                   onChange={(e) => this.filterBenefits(e.target.value)}

--- a/pages/behaviours.js
+++ b/pages/behaviours.js
@@ -21,8 +21,8 @@ class Behaviours extends Component {
       institutions: [],
       benefits: [],
       filteredBenefits: [],
-      currentInstitutionType: "*",
-      currentInstitution: "*",
+      currentInstitutionType: DataFilter.DEFAULT_FILTER_VALUE,
+      currentInstitution: DataFilter.DEFAULT_FILTER_VALUE,
       undisplayedBenefits: [],
       sortBy: null,
       sortAscending: false,
@@ -94,10 +94,10 @@ class Behaviours extends Component {
       undisplayedBenefits,
     })
 
-    const parameters = Url.getParameters(["geographic", "institution"])
+    const parameters = Url.getParameters(["institution_type", "institution"])
     this.filterBenefits(
-      parameters.geographic || "*",
-      parameters.institution || "*"
+      parameters.institution_type || DataFilter.DEFAULT_FILTER_VALUE,
+      parameters.institution || DataFilter.DEFAULT_FILTER_VALUE
     )
 
     this.sortTable("events.show", false)
@@ -107,7 +107,10 @@ class Behaviours extends Component {
     this.setState({ period: period }, this.fetchUsersBehavioursData)
   }
 
-  filterBenefits(institution_type = "*", institution = "*") {
+  filterBenefits(
+    institution_type = DataFilter.DEFAULT_FILTER_VALUE,
+    institution = DataFilter.DEFAULT_FILTER_VALUE
+  ) {
     this.setState(
       DataFilter.benefits(
         this.state.benefits,
@@ -157,6 +160,13 @@ class Behaviours extends Component {
     return Math.min(
       Math.round(((numerator || 0) / (denominator || 1)) * 100),
       100
+    )
+  }
+
+  displayResetButton() {
+    return (
+      this.state.currentInstitutionType !== DataFilter.DEFAULT_FILTER_VALUE ||
+      this.state.currentInstitution !== DataFilter.DEFAULT_FILTER_VALUE
     )
   }
 
@@ -224,7 +234,9 @@ class Behaviours extends Component {
                   }
                   value={this.state.currentInstitution}
                 >
-                  <option value="*">Toutes les institutions</option>
+                  <option value="{DataFilter.DEFAULT_FILTER_VALUE}">
+                    Toutes les institutions
+                  </option>
                   {this.state.filteredInstitutions.map((institution) => (
                     <option value={institution} key={institution}>
                       {institution}
@@ -234,8 +246,7 @@ class Behaviours extends Component {
               </label>
             )}
 
-            {(this.state.currentInstitutionType != "*" ||
-              this.state.currentInstitution != "*") && (
+            {this.displayResetButton() && (
               <input type="reset" onClick={() => this.filterBenefits()} />
             )}
           </div>

--- a/pages/pages.js
+++ b/pages/pages.js
@@ -85,8 +85,7 @@ class PagesVisits extends Component {
       this.state.pagesStats,
       sortingBy,
       sortAscending,
-      ["label"],
-      ["nb_visits", "exit_nb_visits", "exit_rate"]
+      ["label"]
     )
 
     this.setState({

--- a/services/dataFilter.js
+++ b/services/dataFilter.js
@@ -17,14 +17,19 @@ function get(element, depth) {
 }
 
 export default class DataFilter {
-  static benefits(benefits, institutions, geographic = "*", institution = "*") {
+  static benefits(
+    benefits,
+    institutions,
+    institution_type = "*",
+    institution = "*"
+  ) {
     let filteredInstitutions = []
-    if (geographic == "*") {
+    if (institution_type == "*") {
       filteredInstitutions = Object.values(institutions).reduce((accum, el) => {
         return accum.concat(el)
       }, [])
     } else {
-      filteredInstitutions = institutions[geographic]
+      filteredInstitutions = institutions[institution_type]
     }
     filteredInstitutions = filteredInstitutions.sort((a, b) =>
       a.localeCompare(b, "fi")
@@ -32,7 +37,7 @@ export default class DataFilter {
 
     let filteredBenefits = benefits.filter((benefit) => {
       return (
-        (geographic == "*" || benefit.type == geographic) &&
+        (institution_type == "*" || benefit.type == institution_type) &&
         (institution == "*" ||
           benefit.institution == institution ||
           (benefit.institutions && benefit.institutions.includes(institution)))
@@ -40,13 +45,14 @@ export default class DataFilter {
     })
 
     Url.setParameters({
-      geographic: geographic,
-      institution: institution,
+      institution_type,
+      institution,
     })
+
     return {
       filteredInstitutions: filteredInstitutions,
       filteredBenefits: filteredBenefits,
-      currentInstitutionType: geographic,
+      currentInstitutionType: institution_type,
       currentInstitution: institution,
     }
   }

--- a/services/dataFilter.js
+++ b/services/dataFilter.js
@@ -51,13 +51,7 @@ export default class DataFilter {
     }
   }
 
-  static sort(
-    target,
-    sortingBy,
-    sortAscending,
-    alphabeticals = [],
-    numericals = []
-  ) {
+  static sort(target, sortingBy, sortAscending, alphabeticals = []) {
     let output = target
     if (alphabeticals.includes(sortingBy)) {
       if (sortAscending) {
@@ -69,7 +63,7 @@ export default class DataFilter {
           get(b, sortingBy).localeCompare(get(a, sortingBy), "fi")
         )
       }
-    } else if (numericals.includes(sortingBy)) {
+    } else {
       if (sortAscending) {
         output = target.sort((a, b) =>
           numCompare(get(a, sortingBy), get(b, sortingBy))

--- a/services/dataFilter.js
+++ b/services/dataFilter.js
@@ -16,15 +16,17 @@ function get(element, depth) {
   }
 }
 
+const DEFAULT_FILTER_VALUE = "*"
+
 export default class DataFilter {
   static benefits(
     benefits,
     institutions,
-    institution_type = "*",
-    institution = "*"
+    institution_type = DEFAULT_FILTER_VALUE,
+    institution = DEFAULT_FILTER_VALUE
   ) {
     let filteredInstitutions = []
-    if (institution_type == "*") {
+    if (institution_type == DEFAULT_FILTER_VALUE) {
       filteredInstitutions = Object.values(institutions).reduce((accum, el) => {
         return accum.concat(el)
       }, [])
@@ -37,8 +39,9 @@ export default class DataFilter {
 
     let filteredBenefits = benefits.filter((benefit) => {
       return (
-        (institution_type == "*" || benefit.type == institution_type) &&
-        (institution == "*" ||
+        (institution_type == DEFAULT_FILTER_VALUE ||
+          benefit.type == institution_type) &&
+        (institution == DEFAULT_FILTER_VALUE ||
           benefit.institution == institution ||
           (benefit.institutions && benefit.institutions.includes(institution)))
       )
@@ -90,5 +93,9 @@ export default class DataFilter {
     }
 
     return sortAscending
+  }
+
+  static get DEFAULT_FILTER_VALUE() {
+    return DEFAULT_FILTER_VALUE
   }
 }


### PR DESCRIPTION
Cette PR à pour but de fix et d'améliorer la page et le code de la page Behaviour. 

Le bug : 
Quand on récupère la data à afficher sur cette page, on avait une race condition car on fait un setState ET juste après on lance un "sort". Cependant quand le sort se met en marche la data n'est pas encore propagée et donc on sort un array vide (ou le précédent)..

Le fix : c'est fix en faisant le premier sort directement dans la méthode `fetchUsersBehavioursData`

En plus de ça : 
Cette PR, **qui est normalement lisible commit par commit** : 
- Simplifie la logique de "sort"
- renomme un paramètre de filtre
- Ajoute un loader sur la page behaviour
- Split au moins un peu la logique du composant Behaviour