### PR TITLE
Mettre les paramètres à la valeur par default si il ne sont pas défini

### DIFF
--- a/components/surveyDetails.js
+++ b/components/surveyDetails.js
@@ -33,13 +33,19 @@ class SurveyDetails extends Component {
   }
 
   async componentDidMount() {
-    const parameters = Url.getParameters(["institution_type", "institution"])
-    const {
-      institution_type = DataFilter.DEFAULT_FILTER_VALUE,
-      institution = DataFilter.DEFAULT_FILTER_VALUE,
-    } = parameters
+    const { institution_type, institution } = this.retrieveFilterParameters()
 
     this.filterBenefits(institution_type, institution)
+  }
+
+  retrieveFilterParameters() {
+    const parameters = Url.getParameters(["institution_type", "institution"])
+    const { institution_type, institution } = parameters
+
+    return {
+      institution_type: institution_type || DataFilter.DEFAULT_FILTER_VALUE,
+      institution: institution || DataFilter.DEFAULT_FILTER_VALUE,
+    }
   }
 
   filterBenefits(


### PR DESCRIPTION
Note: `institution` et `institution_type` était défini à `null` si non défini dans l'url Du coup ils n'était pas cast à la valeur par défaut ce qui faisait planté la page (à ce niveau : https://github.com/betagouv/mes-aides-analytics/blob/5efbc81572ae29326f7c3597d66fb6306beaf967/services/dataFilter.js#L29-L38)