### PR TITLE
Prend en compte le changement de la clef total

### DIFF
--- a/components/surveyResults.js
+++ b/components/surveyResults.js
@@ -8,6 +8,7 @@ class SurveyResults extends Component {
     super(props)
     this.state = {
       summary: props.summary,
+      total: props.total,
     }
   }
 
@@ -16,7 +17,7 @@ class SurveyResults extends Component {
       <div>
         <h2 data-testid="title">
           Résultats de sondage 7 jours après les simulations (sur{" "}
-          {this.state.summary.total} réponses)
+          {this.state.total} réponses)
         </h2>
 
         <h3>Le sondage</h3>
@@ -39,12 +40,12 @@ class SurveyResults extends Component {
 
         <h3>Résumé du sondage</h3>
         <div className="flex flex-gap">
-          {this.state.summary.total && (
+          {this.state.total && (
             <div className="responsive-chart" data-testid="survey-summary">
               <ResponsiveBar
                 label={(entry) =>
                   `${entry.value} (${Math.round(
-                    (100 * entry.value) / this.state.summary.total,
+                    (100 * entry.value) / this.state.total,
                   )}%)`
                 }
                 data={Object.keys(Config.surveyLabels).map((key) => {

--- a/cypress/fixtures/surveyStatistics.json
+++ b/cypress/fixtures/surveyStatistics.json
@@ -1,7 +1,6 @@
 {
   "survey": {
     "summary": {
-      "total": 2756,
       "already": 39,
       "asked": 1329,
       "failed": 617,
@@ -32,6 +31,7 @@
         "failed": 119,
         "nothing": 771
       }
-    ]
+    ],
+    "total": 2756
   }
 }

--- a/pages/survey.js
+++ b/pages/survey.js
@@ -11,15 +11,18 @@ class Survey extends Component {
       summary: {},
       survey: {},
       institutions: {},
+      total: null,
     }
   }
 
   async componentDidMount() {
-    const { institutions, summary, details } = await Fetch.getSurveyStatistics()
+    const { institutions, summary, total, details } =
+      await Fetch.getSurveyStatistics()
     this.setState({
       institutions: institutions,
       summary: summary,
       survey: details,
+      total: total,
     })
   }
 
@@ -28,7 +31,10 @@ class Survey extends Component {
       <>
         {this.state.survey.length && (
           <>
-            <SurveyResults summary={this.state.summary} />
+            <SurveyResults
+              summary={this.state.summary}
+              total={this.state.total}
+            />
 
             <SurveyDetails
               survey={this.state.survey}

--- a/services/fetch.js
+++ b/services/fetch.js
@@ -21,6 +21,7 @@ export default class Fetch {
 
     return {
       summary: surveyStatiastics.survey.summary,
+      total: surveyStatiastics.survey.total,
       details: surveyStatiastics.survey.details,
       institutions: institutions,
     }


### PR DESCRIPTION
## Détails

La PR [3835](https://github.com/betagouv/aides-jeunes/pull/3835) modifie la position de la clef `total` en la mettant un niveau au dessus de son positionnement passé.

La PR actuelle prend en compte ce changement.

## Schéma de donnée
<table>
<thead>
<tr>
<th>Avant</th>
<th>Après</th>
</tr>
</thead>
<tbody>
<tr>
<td>

```json
"survey": {
    "summary": {
      "total": 14,
      "nothing": 3,
      "failed": 4,
      "asked": 7
    },
    "historical": {
      "2023-04": {
        "nothing": 1,
        "asked": 1
      },
      "2023-03": {
        "nothing": 3,
        "failed": 2,
        "asked": 3
      },
      "2023-06": {
        "nothing": 1,
        "failed": 1,
        "asked": 1
      },
      "2022-06": {
        "failed": 1
      }
    },
}
```

</td>
<td>

```json
"survey": {
    "summary": {
      "nothing": 3,
      "failed": 4,
      "asked": 7
    },
    "historical": {
      "2023-04": {
        "nothing": 1,
        "asked": 1
      },
      "2023-03": {
        "nothing": 3,
        "failed": 2,
        "asked": 3
      },
      "2023-06": {
        "nothing": 1,
        "failed": 1,
        "asked": 1
      },
      "2022-06": {
        "failed": 1
      }
    },
    "total": 14
}
```

</td>
</tr>
</tbody>
</table>
