### PR TITLE
Ajoute un test validant qu'une valeur est présente dans le graphe

### DIFF
--- a/cypress/e2e/survey.cy.js
+++ b/cypress/e2e/survey.cy.js
@@ -38,6 +38,8 @@ describe("Survey Page", () => {
     cy.get("[data-testid=survey-historical-graph] div")
       .invoke("outerHeight")
       .should("be.greaterThan", 0)
+    // related to historical values in fixtures/surveyStatistics.json
+    cy.checkGraph("survey-historical-graph", "2022-08", "5")
   })
 
   context("when select a geographic area", () => {


### PR DESCRIPTION
## Détails

Cette PR ajoute un test utilisant la méthode `cy.checkGraph` pour valider que le graphe contient bien certaines valeurs mockées