### PR TITLE
1460 EPCI benefit simulation statistiques

### DIFF
--- a/components/header.js
+++ b/components/header.js
@@ -7,6 +7,7 @@ const menu = [
   { url: "/behaviours", label: "Comportements utilisateur" },
   { url: "/pages", label: "Statistiques de visite" },
   { url: "/funnel", label: "Tunnel de conversion" },
+  { url: "/institutions", label: "Institutions" },
 ]
 
 function closeMenu() {

--- a/cypress/e2e/institutions.cy.js
+++ b/cypress/e2e/institutions.cy.js
@@ -1,0 +1,70 @@
+import { interceptAidesJeunesStatistics } from "../support/utils.js"
+
+describe("Institution Page Functionalities", () => {
+  beforeEach(() => {
+    const interceptIdentifier = interceptAidesJeunesStatistics()
+    cy.visitFromHome("/institutions")
+    cy.wait(interceptIdentifier)
+  })
+
+  it("displays the navigation menu and page title", () => {
+    cy.checkMenu()
+    cy.checkTitle()
+  })
+
+  it("presents a chart with funnel results", () => {
+    cy.checkTable("institutions-table", 0, "CC du Quercy Caussadais")
+    cy.checkTable("institutions-table", 0, "248200057")
+    cy.checkTable("institutions-table", 0, "CC")
+    cy.checkTable("institutions-table", 0, "20937")
+    cy.checkTable("institutions-table", 0, "0")
+  })
+
+  describe("Filtering Table By Institution Name", () => {
+    beforeEach(() => {
+      cy.get('[data-testid="filter-name"]').type("Tarn-et-Garonnaise")
+    })
+
+    it("shows entries matching the input name", () => {
+      cy.checkTable(
+        "institutions-table",
+        0,
+        "CC de la Lomagne Tarn-et-Garonnaise",
+      )
+    })
+  })
+
+  describe("Filtering Table By Institution Code", () => {
+    beforeEach(() => {
+      cy.get('[data-testid="filter-code"]').type("248200107")
+    })
+
+    it("displays entries corresponding to the input code", () => {
+      cy.checkTable(
+        "institutions-table",
+        0,
+        "CC du Quercy Rouergue et des Gorges de l'Aveyron",
+      )
+    })
+  })
+
+  describe("Filtering Table By Institution Type", () => {
+    beforeEach(() => {
+      cy.get('[data-testid="filter-type"]').select("CA")
+    })
+
+    it("reveals entries of the selected institution type", () => {
+      cy.checkTable("institutions-table", 0, "CA Grand Montauban")
+    })
+  })
+
+  describe("Sorting Table By Population", () => {
+    beforeEach(() => {
+      cy.get('[data-testid="column-population"]').click()
+    })
+
+    it("orders entries based on population", () => {
+      cy.checkTable("institutions-table", 0, "CA Grand Montauban")
+    })
+  })
+})

--- a/cypress/fixtures/aidesJeunesStatistics.json
+++ b/cypress/fixtures/aidesJeunesStatistics.json
@@ -118,5 +118,39 @@
       "showAccompanimentCount": 66,
       "clickAccompanimentCount": 37
     }
-  }
+  },
+  "institutions": [
+    {
+      "name": "CC du Quercy Caussadais",
+      "code": "248200057",
+      "type": "CC",
+      "population": 20937,
+      "simulationCount": 0,
+      "benefitCount": 0
+    },
+    {
+      "name": "CC de la Lomagne Tarn-et-Garonnaise",
+      "code": "248200065",
+      "type": "CC",
+      "population": 10361,
+      "simulationCount": 0,
+      "benefitCount": 0
+    },
+    {
+      "name": "CA Grand Montauban",
+      "code": "248200099",
+      "type": "CA",
+      "population": 80896,
+      "simulationCount": 0,
+      "benefitCount": 1
+    },
+    {
+      "name": "CC du Quercy Rouergue et des Gorges de l'Aveyron",
+      "code": "248200107",
+      "type": "CC",
+      "population": 7864,
+      "simulationCount": 0,
+      "benefitCount": 0
+    }
+  ]
 }

--- a/hooks/fetch-institutions-data.js
+++ b/hooks/fetch-institutions-data.js
@@ -1,0 +1,31 @@
+import { useEffect, useState } from "react"
+
+import TableService from "../services/tableService.js"
+
+const useFetchInstitutionsData = () => {
+  const [dataService, setDataService] = useState(null)
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState(null)
+
+  useEffect(() => {
+    fetch(process.env.aidesJeunesStatisticsURL)
+      .then((response) => {
+        if (!response.ok) {
+          throw new Error("Network response was not ok")
+        }
+        return response.json()
+      })
+      .then((data) => {
+        setDataService(new TableService(data.institutions))
+        setLoading(false)
+      })
+      .catch((error) => {
+        setError(error)
+        setLoading(false)
+      })
+  }, [])
+
+  return { dataService, loading, error }
+}
+
+export default useFetchInstitutionsData

--- a/pages/institutions.js
+++ b/pages/institutions.js
@@ -92,7 +92,7 @@ const InstitutionsStats = () => {
 
   return (
     <>
-      <h2>Statistiques sur les institutions (EPCI)</h2>
+      <h2 data-testid="title">Statistiques sur les institutions (EPCI)</h2>
       <div className="flex-bottom flex-gap">
         <div>
           <label>
@@ -101,6 +101,7 @@ const InstitutionsStats = () => {
               type="text"
               value={queryName}
               onChange={(e) => setQueryName(e.target.value)}
+              data-testid="filter-name"
             />
           </label>
         </div>
@@ -111,6 +112,7 @@ const InstitutionsStats = () => {
               type="text"
               value={queryCode}
               onChange={(e) => setQueryCode(e.target.value)}
+              data-testid="filter-code"
             />
           </label>
         </div>
@@ -120,6 +122,7 @@ const InstitutionsStats = () => {
             <select
               onChange={(e) => setSelectedType(e.target.value)}
               value={selectedType}
+              data-testid="filter-type"
             >
               <option value={allType}>{allType}</option>
               {dataService.getUniqueValuesForKey("type").map((k) => {
@@ -135,7 +138,7 @@ const InstitutionsStats = () => {
       </div>
 
       <div className="flex-bottom flex-gap flex-justify">
-        <table>
+        <table data-testid="institutions-table">
           <thead>
             <tr>
               <th>
@@ -151,6 +154,7 @@ const InstitutionsStats = () => {
                 <div
                   className={`sortable ${getSortOrderClass("population")}`}
                   onClick={() => handleHeaderClick("population")}
+                  data-testid="column-population"
                 >
                   Population
                 </div>

--- a/pages/institutions.js
+++ b/pages/institutions.js
@@ -1,0 +1,194 @@
+import { useState, useEffect } from "react"
+
+import useFetchInstitutionsData from "../hooks/fetch-institutions-data"
+
+const defaultSortOrder = "desc"
+const allType = "Tous"
+
+const filterData = (
+  dataService,
+  queryName,
+  queryCode,
+  selectedType,
+  sortKey,
+  sortOrder,
+) => {
+  let filters = {}
+
+  if (queryName) {
+    filters.name = queryName
+  }
+
+  if (queryCode) {
+    filters.code = queryCode
+  }
+
+  if (selectedType && selectedType !== allType) {
+    filters.type = selectedType
+  }
+
+  let results = dataService.filterByKeys(filters).getResult()
+
+  if (sortKey) {
+    results = dataService.sortByKey(sortKey, sortOrder).getResult()
+  }
+
+  return results
+}
+
+const InstitutionsStats = () => {
+  const { dataService, loading, error } = useFetchInstitutionsData()
+  const [results, setResults] = useState([])
+
+  const [queryName, setQueryName] = useState("")
+  const [queryCode, setQueryCode] = useState("")
+  const [selectedType, setSelectedType] = useState(allType)
+  const [sortKey, setSortKey] = useState(null)
+  const [sortOrder, setSortOrder] = useState(defaultSortOrder)
+
+  useEffect(() => {
+    if (!dataService) {
+      return
+    }
+
+    setResults(
+      filterData(
+        dataService,
+        queryName,
+        queryCode,
+        selectedType,
+        sortKey,
+        sortOrder,
+      ),
+    )
+  }, [queryName, queryCode, selectedType, sortKey, sortOrder, dataService])
+
+  const handleHeaderClick = (newSortKey) => {
+    if (newSortKey === sortKey) {
+      setSortOrder((prevSortOrder) =>
+        prevSortOrder === "asc" ? "desc" : "asc",
+      )
+    } else {
+      setSortKey(newSortKey)
+      setSortOrder(defaultSortOrder)
+    }
+  }
+
+  const getSortOrderClass = (key) => {
+    if (key !== sortKey) {
+      return
+    }
+
+    return sortOrder === "asc" ? "sortable-asc" : "sortable-desc"
+  }
+
+  if (loading) {
+    return <p>Loading...</p>
+  }
+
+  if (error) {
+    return <p>Error: {error.message}</p>
+  }
+
+  return (
+    <>
+      <h2>Statistiques sur les institutions (EPCI)</h2>
+      <div className="flex-bottom flex-gap">
+        <div>
+          <label>
+            <span>Filtrer par nom</span>
+            <input
+              type="text"
+              value={queryName}
+              onChange={(e) => setQueryName(e.target.value)}
+            />
+          </label>
+        </div>
+        <div>
+          <label>
+            <span>Filtrer par code</span>
+            <input
+              type="text"
+              value={queryCode}
+              onChange={(e) => setQueryCode(e.target.value)}
+            />
+          </label>
+        </div>
+        <div>
+          <label>
+            <span>Filtrer par type</span>
+            <select
+              onChange={(e) => setSelectedType(e.target.value)}
+              value={selectedType}
+            >
+              <option value={allType}>{allType}</option>
+              {dataService.getUniqueValuesForKey("type").map((k) => {
+                return (
+                  <option key={k} value={k}>
+                    {k}
+                  </option>
+                )
+              })}
+            </select>
+          </label>
+        </div>
+      </div>
+
+      <div className="flex-bottom flex-gap flex-justify">
+        <table>
+          <thead>
+            <tr>
+              <th>
+                <div>Nom</div>
+              </th>
+              <th>
+                <div>Code</div>
+              </th>
+              <th>
+                <div>Type</div>
+              </th>
+              <th>
+                <div
+                  className={`sortable ${getSortOrderClass("population")}`}
+                  onClick={() => handleHeaderClick("population")}
+                >
+                  Population
+                </div>
+              </th>
+              <th>
+                <div
+                  className={`sortable ${getSortOrderClass("simulationCount")}`}
+                  onClick={() => handleHeaderClick("simulationCount")}
+                >
+                  Nombre de simulation
+                </div>
+              </th>
+              <th>
+                <div
+                  className={`sortable ${getSortOrderClass("benefitCount")}`}
+                  onClick={() => handleHeaderClick("benefitCount")}
+                >
+                  Nombre d'aides
+                </div>
+              </th>
+            </tr>
+          </thead>
+          <tbody>
+            {results.map((row, index) => (
+              <tr key={index}>
+                <td className="text-truncate-ellipsis">{row.name}</td>
+                <td>{row.code}</td>
+                <td>{row.type}</td>
+                <td>{row.population}</td>
+                <td>{row.simulationCount}</td>
+                <td>{row.benefitCount}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </>
+  )
+}
+
+export default InstitutionsStats

--- a/services/tableService.js
+++ b/services/tableService.js
@@ -1,0 +1,34 @@
+export default class DataService {
+  constructor(data) {
+    this.originalData = data
+    this.filteredData = [...data]
+  }
+
+  filterByKeys(filters) {
+    this.filteredData = this.originalData.filter((item) =>
+      Object.entries(filters).every(([key, query]) =>
+        item[key].toLowerCase().includes(query.toLowerCase()),
+      ),
+    )
+    return this
+  }
+
+  sortByKey(key, order = "asc") {
+    const newLocal = order === "asc"
+    this.filteredData = [
+      ...this.filteredData.sort((a, b) =>
+        newLocal ? (a[key] > b[key] ? 1 : -1) : a[key] < b[key] ? 1 : -1,
+      ),
+    ]
+    return this
+  }
+
+  getUniqueValuesForKey(key) {
+    const uniqueValues = new Set(this.originalData.map((item) => item[key]))
+    return Array.from(uniqueValues)
+  }
+
+  getResult() {
+    return this.filteredData
+  }
+}


### PR DESCRIPTION
Ticket: https://trello.com/c/TvwI345k/1460-en-tant-que-charg%C3%A9e-de-d%C3%A9ploiement-je-veux-savoir-dans-quels-epci-jai-des-aides-et-dans-lesquels-je-nen-ai-pas-encore

Ajoute une page pour voir les statistiques sur les institutions : 
<img width="1468" alt="image" src="https://github.com/betagouv/mes-aides-analytics/assets/4059803/dcf86f70-eec4-4050-a19a-8469ecc3a50f">

Pour le moment seulement les EPCI.
Montre la population, le nombre de simulation sur les 6 derniers mois et le nombre d'aides.
Possible de : 
- filtrer par nom, code ou type d'EPCI (filtres cumulables)
- ordonner par population, nombre de simulation ou nombre d'aide (ordres exclusifs)

Tech : Ajoute un service pour filtrer et ordonner les tableau (collection d'objets similaire), on pourra utiliser ça dans d'autres pages pour séparer la logique de fetch de la logique de filtre/ordre.