### PR TITLE
feat: css truncate of `page.label` with ellispsis

### DIFF
--- a/pages/pages.js
+++ b/pages/pages.js
@@ -210,7 +210,7 @@ class PagesVisits extends Component {
               {this.state.pagesStats.length > 0 &&
                 this.state.pagesStats.map((page) => (
                   <tr key={page.label}>
-                    <td>{page.label}</td>
+                    <td className="text-truncate-ellipsis">{page.label}</td>
                     <td className="text-right">{page.nb_visits}</td>
                     <td className="text-right">{page.exit_nb_visits}</td>
                     <td className="text-right">

--- a/public/static/style.css
+++ b/public/static/style.css
@@ -282,6 +282,13 @@ table .sortable-asc:after {
   margin-top: 2rem;
 }
 
+.text-truncate-ellipsis {
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  overflow: hidden;
+  max-width: 20em;
+}
+
 @media (max-width: 1000px) {
   table thead {
     position: relative;


### PR DESCRIPTION
Ticket: https://trello.com/c/cYt3AmKG/1467-supprimer-le-cross-vertical-sur-le-site-de-stats

<img width="1452" alt="image" src="https://github.com/betagouv/mes-aides-analytics/assets/4059803/557e6889-9c4e-4ad3-af7c-db528cdc91f2">
