### PR TITLE
refacto: remove useless useEffect

### DIFF
--- a/pages/institutions.js
+++ b/pages/institutions.js
@@ -1,4 +1,4 @@
-import { useState, useEffect } from "react"
+import { useState } from "react"
 
 import useFetchInstitutionsData from "../hooks/fetch-institutions-data"
 import InfoIcon from "../components/InfoIcon"
@@ -39,7 +39,6 @@ const filterData = (
 
 const InstitutionsStats = () => {
   const { dataService, loading, error } = useFetchInstitutionsData()
-  const [results, setResults] = useState([])
 
   const [queryName, setQueryName] = useState("")
   const [queryCode, setQueryCode] = useState("")
@@ -47,22 +46,17 @@ const InstitutionsStats = () => {
   const [sortKey, setSortKey] = useState(null)
   const [sortOrder, setSortOrder] = useState(defaultSortOrder)
 
-  useEffect(() => {
-    if (!dataService) {
-      return
-    }
-
-    setResults(
-      filterData(
-        dataService,
-        queryName,
-        queryCode,
-        selectedType,
-        sortKey,
-        sortOrder,
-      ),
+  let results = []
+  if (dataService) {
+    results = filterData(
+      dataService,
+      queryName,
+      queryCode,
+      selectedType,
+      sortKey,
+      sortOrder,
     )
-  }, [queryName, queryCode, selectedType, sortKey, sortOrder, dataService])
+  }
 
   const handleHeaderClick = (newSortKey) => {
     if (newSortKey === sortKey) {


### PR DESCRIPTION
> You don’t need Effects to transform data for rendering. (https://react.dev/learn/you-might-not-need-an-effect) 

Les useEffect c'est surtout pour les dépendances externes, call api par exemple. Ici le call api est fait dans un useEffect (dans un hook perso `useFetchInstitutionsData`) et ensuite la filtration/ordonnancement n'a plus besoin d'en utiliser.

