### PR TITLE
fix: Réordonne les mois dans le graphique de sondage

### DIFF
--- a/components/surveyHistorical.js
+++ b/components/surveyHistorical.js
@@ -15,7 +15,7 @@ class SurveyHistorical extends Component {
 
   async componentDidMount() {
     const historicalData = Object.keys(this.state.historical)
-      .sort((a, b) => a > b)
+      .sort()
       .slice(-this.state.monthsToDisplay)
 
     this.setState({


### PR DESCRIPTION
Avant : 
<img width="1484" alt="image" src="https://github.com/betagouv/mes-aides-analytics/assets/4059803/af11adce-fc63-4841-929a-d1e96db64d0d">

Après : 
<img width="1473" alt="image" src="https://github.com/betagouv/mes-aides-analytics/assets/4059803/934de56e-01a5-4864-8170-65ffaa2a0244">

Doc : 
https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/sort#description
