### PR TITLE
1493 ajouter un tunnel de conversion pour simulation recap a partir de la db

### DIFF
--- a/pages/funnel.js
+++ b/pages/funnel.js
@@ -24,7 +24,7 @@ function Funnel() {
     return <p>Chargement...</p>
   }
 
-  const { visitToRecap, surveyData, accompanimentData } =
+  const { visitToResults, surveyData, accompanimentData } =
     chartsData[selectedMonth]
 
   return (
@@ -32,10 +32,10 @@ function Funnel() {
       <h1 data-testid="title">Metriques de parcours {selectedMonth}</h1>
       <div className="funnel-charts">
         <div className="funnel-chart">
-          <h2>Visites - Emails Récapitulatifs</h2>
-          {visitToRecap && (
+          <h2>Visites - Page Résultats</h2>
+          {visitToResults && (
             <DefaultFunnelChart
-              data={visitToRecap}
+              data={visitToResults}
               dataTestid="funnel-visits"
             />
           )}

--- a/pages/funnel.js
+++ b/pages/funnel.js
@@ -24,7 +24,7 @@ function Funnel() {
     return <p>Chargement...</p>
   }
 
-  const { visitToResults, surveyData, accompanimentData } =
+  const { visitToResults, surveyData, accompanimentData, followupData } =
     chartsData[selectedMonth]
 
   return (
@@ -38,6 +38,13 @@ function Funnel() {
               data={visitToResults}
               dataTestid="funnel-visits"
             />
+          )}
+        </div>
+
+        <div className="funnel-chart">
+          <h2>Nombre d'emails récapitulatifs</h2>
+          {followupData && (
+            <DefaultFunnelChart data={followupData} dataTestid="funnel-email" />
           )}
         </div>
 

--- a/public/static/style.css
+++ b/public/static/style.css
@@ -416,7 +416,8 @@ table .sortable-asc:after {
 
 .funnel-charts .funnel-chart {
   flex: 1;
-  max-width: calc(100% / 3);
+  max-width: 50%;
+  flex-basis: 50%;
 }
 
 @media screen and (max-width: 1024px) {

--- a/services/funnelService.js
+++ b/services/funnelService.js
@@ -9,6 +9,10 @@ function formatFunnelData(data) {
       { label: "2ème Page", total: data.secondPageVisits },
       { label: "Page de Résultats", total: data.resultsPageVisits },
     ],
+    followupData: [
+      { label: "avec recontact", total: data.followupWithOptinCount },
+      { label: "sans recontact", total: data.followupWithoutOptinCount },
+    ],
     surveyData: [
       {
         label: "Email de sondage envoyés",

--- a/services/funnelService.js
+++ b/services/funnelService.js
@@ -4,7 +4,7 @@ import configuration from "../next.config.js"
 
 function formatFunnelData(data) {
   return {
-    visitToRecap: [
+    visitToResults: [
       { label: "1ère Page", total: data.firstPageVisits },
       { label: "2ème Page", total: data.secondPageVisits },
       { label: "Page de Résultats", total: data.resultsPageVisits },


### PR DESCRIPTION
Fix du wording sur le premier graph 
Plus ticket : https://trello.com/c/ORO6a2zm/1493-ajouter-un-tunnel-de-conversion-pour-simulation-r%C3%A9cap-%C3%A0-partir-de-la-db

PS stats déjà calculée : 
<img width="389" alt="image" src="https://github.com/betagouv/mes-aides-analytics/assets/4059803/3b5c697c-d01d-4ba3-9ab0-07514e4f6e60">

Résultat : 
<img width="589" alt="image" src="https://github.com/betagouv/mes-aides-analytics/assets/4059803/e378ee37-de0a-46ad-b5a1-64d0e495feb2">

