### PR TITLE
Fusionne les évènements apparentés

### DIFF
--- a/services/config.js
+++ b/services/config.js
@@ -93,6 +93,7 @@ export const EventTypeCategoryMapping = {
     cat: EventCategories.ACTIONABLE,
     name: "Téléservice",
     color: "#7f7f7f",
+    relatedCategories: ["teleservicePrefill"],
   },
   "link-ineligible": {
     cat: EventCategories.INELIGIBLE_ACTIONABLE,


### PR DESCRIPTION
Ticket: https://trello.com/c/i9fwJ2kY/1494-prendre-en-compte-les-teleserviceprefill-dans-les-stats

Dans notre cas, `teleservicePrefill` est une catégorie apparentée à `teleservice`