### PR TITLE
1517 revoir le graphique des recap sur le site de stats

### DIFF
--- a/components/defaultFunnelChart.js
+++ b/components/defaultFunnelChart.js
@@ -23,7 +23,7 @@ export const DefaultFunnelChart = ({ data, dataTestid }) => {
         data={data}
         indexBy={xAxisKey}
         keys={keys}
-        groupMode="stacked"
+        groupMode="grouped"
         margin={{ top: 15, right: 10, bottom: 150, left: 60 }}
         padding={0.1}
         animate={false}

--- a/cypress/fixtures/aidesJeunesStatistics.json
+++ b/cypress/fixtures/aidesJeunesStatistics.json
@@ -111,13 +111,19 @@
       "firstPageVisits": 127857,
       "secondPageVisits": 102925,
       "resultsPageVisits": 76436,
-      "simulationCount": 25,
-      "followupWithOptinCount": 16,
-      "followupWithoutOptinCount": 0,
-      "followupWithSurveyCount": 2,
+      "simulationCount": 0,
+      "followupWithOptinCount": 56,
+      "followupWithoutOptinCount": 95,
+      "followupWithOptinCountSms": 2,
+      "followupWithoutOptinCountSms": 3,
+      "followupWithOptinCountEmail": 24,
+      "followupWithoutOptinCountEmail": 55,
+      "followupWithOptinCountEmailAndSms": 30,
+      "followupWithoutOptinCountEmailAndSms": 37,
+      "followupWithSurveyCount": 54,
       "followupWithSurveyRepliedCount": 2,
-      "showAccompanimentCount": 66,
-      "clickAccompanimentCount": 37
+      "showAccompanimentCount": 22,
+      "clickAccompanimentCount": 26
     }
   },
   "institutions": [

--- a/pages/funnel.js
+++ b/pages/funnel.js
@@ -42,7 +42,7 @@ function Funnel() {
         </div>
 
         <div className="funnel-chart">
-          <h2>Nombre d'emails récapitulatifs</h2>
+          <h2>Nombre d'emails et/ou sms récapitulatifs</h2>
           {followupData && (
             <DefaultFunnelChart data={followupData} dataTestid="funnel-email" />
           )}

--- a/services/funnelService.js
+++ b/services/funnelService.js
@@ -10,8 +10,18 @@ function formatFunnelData(data) {
       { label: "Page de Résultats", total: data.resultsPageVisits },
     ],
     followupData: [
-      { label: "avec recontact", total: data.followupWithOptinCount },
-      { label: "sans recontact", total: data.followupWithoutOptinCount },
+      {
+        label: "avec recontact",
+        Sms: data.followupWithOptinCountSms,
+        Email: data.followupWithOptinCountEmail,
+        "Email et Sms": data.followupWithOptinCountEmailAndSms,
+      },
+      {
+        label: "sans recontact",
+        Sms: data.followupWithoutOptinCountSms,
+        Email: data.followupWithoutOptinCountEmail,
+        "Email et Sms": data.followupWithoutOptinCountEmailAndSms,
+      },
     ],
     surveyData: [
       {


### PR DESCRIPTION
<img width="724" alt="image" src="https://github.com/betagouv/mes-aides-analytics/assets/4059803/4b3db89d-1910-456d-8b53-433b9fea59c1">
Avec le hover de la souris
<img width="709" alt="image" src="https://github.com/betagouv/mes-aides-analytics/assets/4059803/ca758b92-aa3f-4695-9bbe-1f54fbb670c7">


⚠️ Les nombres ne sont pas réels

Ticket: https://trello.com/c/OyepMAWz/1517-revoir-le-graphique-des-r%C3%A9cap-sur-le-site-de-stats
Précédé par : https://github.com/betagouv/aides-jeunes/pull/4078