### PR TITLE
Ajuste les sources des données Matomo suite à sa migration vers beta.gouv.fr

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -9,7 +9,11 @@ const configuration = {
     : undefined,
   basePath: isProduction ? "/mes-aides-analytics" : undefined,
   env: {
+    // There is and old and a current usage stats URL
+    // because of the matomo migration (data.gouv.fr -> stats.data.gouv.fr) in august 2024
     usageStatisticsURL:
+      "https://stats.beta.gouv.fr/index.php?date=2024-08-01,yesterday&expanded=1&filter_limit=100&force_api_session=1&format=JSON&format_metrics=1&idSite=63&method=API.get&module=API&period=month&token_auth=anonymous",
+    usageStatisticsOldURL:
       "https://stats.data.gouv.fr/index.php?date=2021-01-01,yesterday&expanded=1&filter_limit=100&force_api_session=1&format=JSON&format_metrics=1&idSite=165&method=API.get&module=API&period=month&token_auth=anonymous",
     observatoryURL:
       "https://observatoire.numerique.gouv.fr/Demarches/3135?view-mode=statistics&date-debut=2020-07-01&date-fin=",

--- a/next.config.js
+++ b/next.config.js
@@ -21,7 +21,7 @@ const configuration = {
       "https://mes-aides.1jeune1solution.beta.gouv.fr/documents/stats.json",
     benefitsURL: `${aidesJeunesUrl}api/benefits`,
     pagesStatsURL:
-      "https://stats.data.gouv.fr/index.php?module=API&format=JSON&idSite=165&period=range&method=Actions.getExitPageUrls&expanded=1&date=",
+      "https://stats.beta.gouv.fr/index.php?module=API&format=JSON&idSite=63&period=range&method=Actions.getExitPageUrls&expanded=1&date=",
     benefitDetailURL: `${aidesJeunesUrl}aides/`,
     recorderStatisticsURL:
       process.env.RECORDER_STATISTICS_URL ||

--- a/pages/index.js
+++ b/pages/index.js
@@ -82,12 +82,21 @@ class Index extends Component {
           <a
             target="_blank"
             rel="noreferrer"
-            href="https://stats.data.gouv.fr/index.php?idSite=165&module=MultiSites&action=index&date=yesterday&period=month"
+            href="https://stats.data.gouv.fr/index.php?idSite=165&module=MultiSites&action=index&date=2024-07-29&period=month"
           >
             la page suivante
           </a>{" "}
-          et à côté des statistiques d'usage d'autres Startups d'État. Sur
-          Matomo, le simulateur est intitulé « aides-jeunes ».
+          pour les données jusqu'à juillet 2024 (site web « aides-jeunes ») et{" "}
+          <a
+            target="_blank"
+            rel="noreferrer"
+            href="https://stats.beta.gouv.fr/index.php?module=MultiSites&action=index&idSite=63&period=month&date=yesterday"
+          >
+            la page suivante
+          </a>{" "}
+          pour les données à partir d'août 2024 (site web «
+          mes-aides.1jeune1solution.beta.gouv.fr »), à côté des statistiques
+          d'usage d'autres Startups d'État.
         </p>
 
         <h2>Observatoire de la qualité des démarches en ligne</h2>

--- a/pages/index.js
+++ b/pages/index.js
@@ -29,7 +29,11 @@ class Index extends Component {
   }
 
   async fetchData() {
-    const globalStats = await Fetch.getJSON(process.env.usageStatisticsURL)
+    const globalOldStats = await Fetch.getJSON(
+      process.env.usageStatisticsOldURL,
+    )
+    const globalNewStats = await Fetch.getJSON(process.env.usageStatisticsURL)
+    const globalStats = { ...globalOldStats, ...globalNewStats }
     return Object.keys(globalStats).map((m) => {
       return {
         month: m,


### PR DESCRIPTION
Concaténation des données avant août 2024 du Matomo data.gouv.fr  avec les données après juillet 2024 du Matomo beta.gouv.fr